### PR TITLE
gcloud: compute (part A)

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  trailingComma: "es5",
+  tabWidth: 2,
+  semi: true,
+  singleQuote: false,
+};

--- a/services/gcp/compute/acceleratorTypes.yml
+++ b/services/gcp/compute/acceleratorTypes.yml
@@ -1,0 +1,13 @@
+name: Compute Engine accelerator-optimized machines
+description: >-
+  Read accelerator-optimized machine types
+scope: PUBLIC
+notes: >-
+  Reads publicly available data from Google Cloud
+privileges:
+  get:
+    vulnerabilities: []
+  list:
+    vulnerabilities: []
+links:
+  - https://cloud.google.com/compute/docs/accelerator-optimized-machines

--- a/services/gcp/compute/addresses.yml
+++ b/services/gcp/compute/addresses.yml
@@ -1,0 +1,46 @@
+name: Compute Engine addresses
+description: >-
+  Read and edit Compute Engine addresses
+scope: LOW
+notes: >-
+  Allows discovering, reserving, and modifying IP addresses within Compute Engine.
+  If IP ranges are narrowly constrained (e.g., from a /28 range),
+  may allow an attacker to deny access to infrastructure.
+privileges:
+  create:
+    scope: LOW
+    vulnerabilities: [infrastructure:consumption]
+  createInternal:
+    scope: LOW
+    vulnerabilities: [infrastructure:consumption]
+  delete:
+    vulnerabilities: [destruction:infra]
+    notes: >-
+      Can not delete an address that is in use by an instance.
+  deleteInternal:
+    vulnerabilities: [destruction:infra]
+    notes: >-
+      Can not delete an address that is in use by an instance.
+  get:
+    vulnerabilities: [discovery:network]
+    notes: >-
+      May allow an attacker to identify network resources to target.
+  list:
+    vulnerabilities: [discovery:network]
+    notes: >-
+      May allow an attacker to identify network resources to target.
+  setLabels:
+    vulnerabilities: [destruction:infra]
+  use:
+    vulnerabilities: [escalation:lateral]
+    notes: >-
+      If used to attach a network address to an already compromised access, can
+      allow lateral movement across a network.
+  useInternal:
+    vulnerabilities: [escalation:lateral]
+    notes: >-
+      If used to attach a network address to an already compromised access, can
+      allow lateral movement across a network.
+links:
+  - https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+  - https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address

--- a/services/gcp/compute/autoscalers.yml
+++ b/services/gcp/compute/autoscalers.yml
@@ -1,0 +1,21 @@
+name: Compute Engine autoscalers
+description: >-
+  Read and edit Compute Engine autoscaling groups.
+scope: MEDIUM
+notes: >-
+  Note that autoscaling is only applicable if the resource uses
+  managed instance groups (MIGs). Generally requires
+  `compute.instanceGroupManagers.use`.
+privileges:
+  create:
+    vulnerabilities: [impact:spend, impact:hijacking]
+  delete:
+    vulnerabilities: [destruction:infra]
+  get:
+    vulnerabilities: [discovery:infra]
+  list:
+    vulnerabilities: [discovery:infra]
+  update:
+    vulnerabilities: [impact:spend, impact:hijacking, destruction:infra]
+links:
+  - https://cloud.google.com/compute/docs/autoscaler

--- a/services/gcp/compute/backendBuckets.yml
+++ b/services/gcp/compute/backendBuckets.yml
@@ -1,0 +1,56 @@
+name: Compute Engine backend buckets
+description: >-
+  Cloud Storage buckets that may be referenced by load-balancer
+  URL maps, or via Cloud CDN.
+scope: HIGH
+notes: >-
+  Generally used for providing publicly accessible data via a load balancer.
+  This scope may depend on the exact configuration of the load balancer (e.g.
+  if the load balancer requires certain cookies or auth tokens), and
+  whether the load balancer itself is intended to be publicly accessible.
+  The scope of read permissions should be downgraded to PUBLIC if only
+  publicly accessible data are contained within these buckets.
+privileges:
+  addSignedUrlKey:
+    vulnerabilities: [privilege:escalation]
+    notes: >-
+      Allows an attacker to forge signed URLs, potentially gaining access to additional
+      data.
+  create:
+    vulnerabilities: []
+  delete:
+    vulnerabilities: [destruction:infra, destruction:data]
+  deleteSignedUrlKey:
+    vulnerabilities: [destruction:infra]
+  get:
+    vulnerabilities: [discovery:infra]
+  getIamPolicy:
+    vulnerabilities: [discovery:policy]
+  list:
+    vulnerabilities: [discovery:infra]
+  setIamPolicy:
+    vulnerabilities: [escalation:privilege]
+  setSecurityPolicy:
+    vulnerabilities: [escalation:privilege]
+    notes: >-
+      Allows an attacker to defeat content security, gaining access to bucket contents.
+    links:
+      - https://cloud.google.com/armor/docs/security-policy-overview
+  update:
+    vulnerabilities: [destruction:infra, destruction:data, escalation:privilege]
+    notes: >-
+      May allow modifications to CDN and edge security policies.
+    links:
+      - https://cloud.google.com/armor/docs/security-policy-overview
+  use:
+    vulnerabilities: [escalation:lateral]
+    notes: >-
+      When combined with the ability to edit URL maps, allows an attacker to point a
+      load-balancer URL to a backend bucket.
+    links:
+      - https://cloud.google.com/compute/docs/reference/rest/v1/urlMaps/insert
+links:
+  - https://cloud.google.com/load-balancing/docs/https/ext-load-balancer-backend-buckets
+  - https://cloud.google.com/compute/docs/reference/rest/v1/backendBuckets
+seeAlso:
+  - compute.backendServices

--- a/services/gcp/compute/backendServices.yml
+++ b/services/gcp/compute/backendServices.yml
@@ -1,0 +1,52 @@
+name: Compute Engine backend services
+description: >-
+  Backend endpoints that may be referenced by load-balancer
+  URL maps, or via Cloud CDN.
+scope: HIGH
+notes: >-
+  Used to serve dynamic content via a load balancer.
+privileges:
+  addSignedUrlKey:
+    vulnerabilities: [privilege:escalation]
+    notes: >-
+      Allows an attacker to forge signed URLs, potentially gaining access to additional
+      data.
+  create:
+    vulnerabilities: []
+  delete:
+    vulnerabilities: [destruction:infra]
+  deleteSignedUrlKey:
+    vulnerabilities: [destruction:infra]
+  get:
+    vulnerabilities: [discovery:infra]
+  getIamPolicy:
+    vulnerabilities: [discovery:policy]
+  list:
+    vulnerabilities: [discovery:infra]
+  setIamPolicy:
+    vulnerabilities: [escalation:privilege]
+  setSecurityPolicy:
+    vulnerabilities: [escalation:privilege]
+    notes: >-
+      Allows an attacker to defeat content security, potentially gaining layer-7
+      access to the service.
+    links:
+      - https://cloud.google.com/armor/docs/security-policy-overview
+  update:
+    vulnerabilities: [destruction:infra, destruction:data, escalation:privilege]
+    notes: >-
+      May allow modifications to CDN and edge security policies.
+    links:
+      - https://cloud.google.com/armor/docs/security-policy-overview
+  use:
+    vulnerabilities: [escalation:lateral]
+    notes: >-
+      When combined with the ability to edit URL maps, allows an attacker to point a
+      load-balancer URL to a backend service.
+    links:
+      - https://cloud.google.com/compute/docs/reference/rest/v1/urlMaps/insert
+links:
+  - https://cloud.google.com/load-balancing/docs/backend-service
+  - https://cloud.google.com/compute/docs/reference/rest/v1/backendServices
+seeAlso:
+  - compute.backendBuckets

--- a/services/gcp/compute/commitments.yml
+++ b/services/gcp/compute/commitments.yml
@@ -1,0 +1,21 @@
+name: Compute Engine commitments
+description: >-
+  Manage committed use discounts.
+scope: MEDIUM
+notes: >-
+  Commitments affect operational cost.
+privileges:
+  create:
+    vulnerabilities: [impact:spend]
+  get:
+    vulnerabilities: [discovery:infra]
+    scope: LOW
+  list:
+    vulnerabilities: [discovery:infra]
+    scope: LOW
+  update:
+    vulnerabilities: [impact:spend]
+  updateReservations:
+    vulnerabilities: [impact:spend]
+links:
+  - https://cloud.google.com/compute/docs/instances/committed-use-discounts-overview

--- a/services/gcp/compute/diskTypes.yml
+++ b/services/gcp/compute/diskTypes.yml
@@ -1,0 +1,14 @@
+name: Compute Engine disk types
+description: >-
+  Read available disk types
+scope: PUBLIC
+notes: >-
+  Reads publicly available data from Google Cloud
+privileges:
+  get:
+    vulnerabilities: []
+  list:
+    vulnerabilities: []
+links:
+  - https://cloud.google.com/compute/docs/disks
+  - https://cloud.google.com/compute/docs/reference/rest/v1/diskTypes

--- a/services/gcp/compute/disks.yml
+++ b/services/gcp/compute/disks.yml
@@ -1,0 +1,90 @@
+name: Compute Engine disks
+description: >-
+  Read and edit Compute Engine disks and disk assignments.
+scope: CRITICAL
+notes: >-
+  Multiple organizational functions may often reside within
+  Compute Engine.
+privileges:
+  addResourcePolicies:
+    vulnerabilities: [impact:spend, collection:data]
+    notes: >-
+      Requires a useful resource policy to otherwise exist.
+    links:
+      - https://cloud.google.com/compute/docs/reference/rest/v1/resourcePolicies
+      - https://cloud.google.com/compute/docs/disks/scheduled-snapshots
+  create:
+    vulnerabilities: [impact:spend]
+  createSnapshot:
+    scope: HIGH
+    notes: >-
+      When combined with the ability to read disk images, can allow access
+      to disk data.
+    vulnerabilities: [collection:data]
+  createTagBinding:
+    vulnerabilities: [escalation:privilege]
+    notes: >-
+      Tag bindings are used to dynamically modify IAM policies.
+  delete:
+    vulnerabilities: [destruction:infra, destruction:data]
+  deleteTagBinding:
+    vulnerabilities: [escalation:privilege, destruction:policy]
+    notes: >-
+      Tag bindings are used to dynamically modify IAM policies.
+  get:
+    vulnerabilities: [discovery:infra]
+  getIamPolicy:
+    vulnerabilities: [discovery:policy]
+  list:
+    vulnerabilities: [discovery:infra]
+  listEffectiveTags:
+    vulnerabilities: [discovery:policy]
+  listTagBindings:
+    vulnerabilities: [discovery:policy]
+  removeResourceBindings:
+    vulnerabilities: [destruction:infra]
+    links:
+      - https://cloud.google.com/compute/docs/reference/rest/v1/resourcePolicies
+      - https://cloud.google.com/compute/docs/disks/scheduled-snapshots
+  resize:
+    vulnerabilities: [impact:spend]
+    notes: >-
+      Disks can only be increased in size.
+    links:
+      - https://cloud.google.com/compute/docs/reference/rest/v1/disks/resize
+  setIamPolicy:
+    vulnerabilities: [escalation:privilege]
+  setLabels:
+    vulnerabilities: [destruction:infra]
+  startAsyncReplication:
+    vulnerabilities: []
+    links:
+      - https://cloud.google.com/compute/docs/disks/async-pd/about
+  stopAsyncReplication:
+    vulnerabilities: [destruction:infra]
+    notes: >-
+      Can effectively turn off disk replication if applied repeatedly.
+    links:
+      - https://cloud.google.com/compute/docs/disks/async-pd/about
+  stopGroupAsyncReplication:
+    vulnerabilities: [destruction:infra]
+    notes: >-
+      Can effectively turn off disk replication if applied repeatedly.
+    links:
+      - https://cloud.google.com/compute/docs/disks/async-pd/about
+  update:
+    vulnerabilities: [escalation:data, destruction:infra]
+    notes: >-
+      Can allow data access via modifying disk or snapshot encryption keys.
+  use:
+    vulnerabilities: [collection:data, destruction:data]
+    notes: >-
+      Can allow data access if the attacker can attach the disk to an additionally
+      compromised instance.
+  useReadOnly:
+    vulnerabilities: [collection:data]
+    notes: >-
+      Can allow data access if the attacker can attach the disk to an additionally
+      compromised instance.
+links:
+  - https://cloud.google.com/compute/docs/disks/persistent-disks

--- a/services/gcp/compute/externalVpnGateways.yml
+++ b/services/gcp/compute/externalVpnGateways.yml
@@ -1,0 +1,28 @@
+name: Compute Engine external VPN gateways
+description: >-
+  Manage external access points to Compute Engine VPNs (e.g.,
+  network gateways).
+scope: CRITICAL
+notes: >-
+  Multiple organizational functions may often reside within
+  Compute Engine.
+privileges:
+  create:
+    vulnerabilities: []
+  delete:
+    vulnerabilities: [destruction:network]
+  get:
+    vulnerabilities: [discovery:network]
+  list:
+    vulnerabilities: [discovery:network]
+  setLabels:
+    vulnerabilities: [destruction:infra]
+  use:
+    vulnerabilities: [escalation:lateral]
+    notes: >-
+      Can be used to gain network access when the attacker has
+      access to both the gateway in question, and the ability to
+      modify the VPN settings.
+links:
+  - https://cloud.google.com/network-connectivity/docs/vpn/concepts/overview
+  - https://cloud.google.com/network-connectivity/docs/vpn/how-to/configuring-peer-gateway

--- a/vulnerabilities/discovery/network.yml
+++ b/vulnerabilities/discovery/network.yml
@@ -1,0 +1,12 @@
+name: Network discovery
+description: |
+  Allows an attacker to inventory network resources.
+  May allow an attacker to focus attacks on specific network
+  locations.
+risk: LOW
+mitigations:
+  - Use network filtering
+  - Use network segmentation
+  - Apply zero-trust networking principles
+links:
+  - https://attack.mitre.org/techniques/T1046/

--- a/vulnerabilities/impact/consumption.yml
+++ b/vulnerabilities/impact/consumption.yml
@@ -1,0 +1,7 @@
+name: Infrastructure consumption
+description: |
+  Allows an attacker to consume resources from a potentially
+  limited pool. This may impact the time to assign resouces.
+risk: LOW
+mitigations: []
+links: []


### PR DESCRIPTION
Compute permissions for components acceleratorTypes through externalVpnGateways.  Also add prettier config and two new vulnerabilities for network discovery and consumption.