### PR TITLE
Run Lint and Validate before Deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,30 +1,38 @@
 name: Deploy catalog
 
 on:
-  pull_request:
   push:
     branches: [main]
   workflow_dispatch:
 
+# By setting the concurrency to a constant string value,
+# only one pipeline can run at the same time.
+# Pipeline from another merge will be in pending state until
+# the current pipeline finishes.
+# If yet another merge happens, the pending pipeline is cancelled.
+# (Only one pipeline is in pending state at any time)
+# See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency: main-deploy
+
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+    secrets: inherit
+  validate:
+    uses: ./.github/workflows/validate.yml
+    secrets: inherit
   deploy:
+    needs: [lint, validate]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
     strategy:
       matrix:
-        project_number: ["398809717501"] #, "615473322806", "228132571547"]
-        environment: [test] #, stage, prod]
-        project_id: [p0-gcp-project] #, p0-stage, p0-prod]
+        project_number: ["398809717501", "615473322806", "228132571547"]
+        environment: [test, stage, prod]
+        project_id: [p0-gcp-project, p0-stage, p0-prod]
     steps:
-      # - name: Install google-cloud-sdk
-      #   run: |
-      #     sudo apt-get install apt-transport-https ca-certificates gnupg && \
-      #       (echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list) && \
-      #       (curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -) && \
-      #       sudo apt-get update && \
-      #       sudo apt-get install google-cloud-sdk
       - id: checkout
         uses: actions/checkout@v3
       - id: auth

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,6 @@
 on:
   pull_request: {}
-  push:
-    branches: [main]
+  workflow_call:
 
 name: Lint
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,6 @@
 on:
   pull_request: {}
-  push:
-    branches: [main]
+  workflow_call:
 
 name: Validate
 


### PR DESCRIPTION
Trigger Lint and Validate workflows from the CD workflow only if they succeeded. Uncomment staging and prod projects from deploy. Limit concurrent deploy runs to 1.