### PR TITLE
vulnerabilities: Clean up naming

### DIFF
--- a/vulnerabilities/destruction/crypto.yml
+++ b/vulnerabilities/destruction/crypto.yml
@@ -1,6 +1,6 @@
-name: Crypto destruction
+name: Cryptographic destruction
 description: |
-  Allows an attacker to delete secret data, such as credentials and API keys.
+  Allows an attacker to delete secret data, such as encryption keys, or private components of asymmetric keys.
 risk: CRITICAL
 mitigations:
 links:

--- a/vulnerabilities/escalation/network.yml
+++ b/vulnerabilities/escalation/network.yml
@@ -1,7 +1,8 @@
-name: Movement across a network
+name: Network movement
 description: >-
   Allows an attacker to gain access to additional resources on the same network.
 risk: BOOST
 mitigations:
   - Use network segmentation
 links:
+  - https://attack.mitre.org/techniques/T1021/

--- a/vulnerabilities/exfiltration/crypto.yml
+++ b/vulnerabilities/exfiltration/crypto.yml
@@ -1,4 +1,4 @@
-name: Exfiltration of cryptographic data
+name: Cryptographic exfiltration
 description: >-
   Allows an attacker to export cryptographic material from a system,
   including secret keys.

--- a/vulnerabilities/impact/access.yml
+++ b/vulnerabilities/impact/access.yml
@@ -1,8 +1,9 @@
-name: Access
+name: Denial-of-access
 description: >-
   Allows an attacker to prevent authorized operational
   access. This can allow an attacker to continue system
   abuse.
 risk: EVASION
 mitigations: []
-links: []
+links:
+  - https://attack.mitre.org/techniques/T1531/

--- a/vulnerabilities/impact/encryption.yml
+++ b/vulnerabilities/impact/encryption.yml
@@ -1,4 +1,4 @@
-name: Encryption
+name: Data encryption
 description: >-
   Allows an attacker to encrypt data within a system. This can be used to
   either make data permanently inaccessible, or extort compensation for

--- a/vulnerabilities/persistence/account.yml
+++ b/vulnerabilities/persistence/account.yml
@@ -1,7 +1,7 @@
 name: Account persistence
 description: >-
   Allows an attacker to maintain access to the target system by manipulating existing accounts or creating new accounts. This can include modifying credentials and permission groups and other activity designed to subvert security policies.
-risk: MEDIUM
+risk: BOOST
 mitigations:
   - Use least-privileged access
   - Use multi-factor authentication for user and privileged accounts


### PR DESCRIPTION
Optimize for a sweet spot of detail and readability in vulnerability titles (viz., two-three words).

Also add missing MITRE links.