### PR TITLE
ci: Remove submodule read

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,9 +11,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
-          token: ${{ secrets.READ_P0_REPOS }}
       - uses: actions/setup-node@v3
         with:
           node-version: ^18.6.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,9 +11,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
-          token: ${{ secrets.READ_P0_REPOS }}
       - uses: actions/setup-node@v3
         with:
           node-version: ^18.6.0


### PR DESCRIPTION
We don't use them, and don't have the secret available on a public repo.