### PR TITLE
dataproc: Add clusters

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -11,6 +11,7 @@
     "cryptomining",
     "cryptojacking",
     "DaemonSet",
+    "Dataproc",
     "exfiltrate",
     "exfiltration",
     "finalizer",

--- a/services/gcp/compute/instances.yml
+++ b/services/gcp/compute/instances.yml
@@ -38,7 +38,6 @@ privileges:
       - discovery:policy
       - takeover:account
       - exfiltration:crypto
-      - takeover:account
       - escalation:network
       - impact:spend
       - impact:hijack

--- a/services/gcp/compute/instances.yml
+++ b/services/gcp/compute/instances.yml
@@ -36,15 +36,13 @@ privileges:
     risks:
       - discovery:network
       - discovery:policy
-      - takeover:account
-      - exfiltration:crypto
       - escalation:network
       - impact:spend
       - impact:hijack
     notes: >-
       Creating an instance can export the instance's service account credentials to an external
       server using the VM's local access to the instance metadata, including disk encryption
-      keys and service account tokens. Allows access to network instances to which the VM is
+      keys and short-lived service account tokens. Allows access to network instances to which the VM is
       connected (e.g. VPCs). Created instances can be used to hijack resources, or create extra spend.
       Creating an instance with an attached service account requires permissions to impersonate the service account.
     links:
@@ -150,10 +148,7 @@ privileges:
       - discovery:network
       - discovery:policy
       - escalation:lateral
-      - takeover:account
       - exfiltration:data
-      - exfiltration:crypto
-      - takeover:account
       - impact:defacement
       - impact:hijack
     notes: >-
@@ -358,14 +353,14 @@ privileges:
       Can be used to disable secure boot, remove the vTPM from the instance, or disable integrity
       monitoring. Requires the instance to be stopped.
   use:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral]
     scope: HIGH
     notes: >-
       Can be used to connect the instance to other components, potentially allowing additional
       access. For example, adding the instance to an instance group can allow the instance's
       network to be accessible.
   useReadOnly:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral]
     scope: HIGH
     notes: >-
       Can be used to connect the instance to other components, potentially allowing additional

--- a/services/gcp/dataproc/clusters.yml
+++ b/services/gcp/dataproc/clusters.yml
@@ -4,18 +4,15 @@ description: >-
   running Apache Hadoop, Hive, Pig, and Spark jobs.
 scope: MEDIUM
 notes: >-
-  Allows access to machine-learning pipelines. Creating a cluster allows takeover of
-  the default Dataproc service account.
+  Allows access to machine-learning pipelines. Creating a cluster allows exfiltration
+  of the default service account tokens.
 privileges:
   create:
-    scope: CRITICAL
     risks:
-      - exfiltration:crypto
-      - takeover:account
       - impact:spend
     notes: >-
-      Creating a Dataproc cluster allows the ability to takeover the
-      Dataproc service account.
+      Creating a Dataproc cluster provides access to the cluster's short-lived service account token.
+      `serviceAccount.actAs` permission is necessary to create a cluster with this account.
     links:
       - https://www.youtube.com/watch?v=kyqeBGNSEIc
       - https://www.blackhat.com/us-20/briefings/schedule/#lateral-movement-and-privilege-escalation-in-gcp-compromise-any-organization-without-dropping-an-implant-19435
@@ -50,12 +47,10 @@ privileges:
       Allows the caller to update the number of instances the job uses.
   use:
     risks:
-      - exfiltration:crypto
-      - takeover:account
       - impact:spend
     notes: >-
       Allows the caller to submit a job to the cluster. Jobs may gain access
-      to the cluster's service account.
+      to the cluster's short-lived service-account credentials.
     links:
       - https://www.youtube.com/watch?v=kyqeBGNSEIc
       - https://www.blackhat.com/us-20/briefings/schedule/#lateral-movement-and-privilege-escalation-in-gcp-compromise-any-organization-without-dropping-an-implant-19435

--- a/services/gcp/dataproc/clusters.yml
+++ b/services/gcp/dataproc/clusters.yml
@@ -1,0 +1,65 @@
+name: Dataproc clusters
+description: >-
+  Create and manage Dataproc clusters. Dataproc clusters provide a platform for
+  running Apache Hadoop, Hive, Pig, and Spark jobs.
+scope: MEDIUM
+notes: >-
+  Allows access to machine-learning pipelines. Creating a cluster allows takeover of
+  the default Dataproc service account.
+privileges:
+  create:
+    scope: CRITICAL
+    risks:
+      - exfiltration:crypto
+      - takeover:account
+      - impact:spend
+    notes: >-
+      Creating a Dataproc cluster allows the ability to takeover the
+      Dataproc service account.
+    links:
+      - https://www.youtube.com/watch?v=kyqeBGNSEIc
+      - https://www.blackhat.com/us-20/briefings/schedule/#lateral-movement-and-privilege-escalation-in-gcp-compromise-any-organization-without-dropping-an-implant-19435
+  delete:
+    risks:
+      - destruction:infra
+  get:
+    risks: []
+    notes: >-
+      Allows retrieval of the cluster's configuration and status only.
+  getIamPolicy:
+    risks:
+      - discovery:account
+      - discovery:policy
+  list:
+    risks: [discovery:infra]
+    notes: See `get`.
+  setIamPolicy:
+    risks:
+      - destruction:policy
+      - escalation:privilege
+      - impact:access
+  start:
+    risks: [impact:spend]
+  stop:
+    risks: []
+    notes: >-
+      Job state will be lost, but in general jobs will be idempotent.
+  update:
+    risks: [impact:spend]
+    notes: >-
+      Allows the caller to update the number of instances the job uses.
+  use:
+    risks:
+      - exfiltration:crypto
+      - takeover:account
+      - impact:spend
+    notes: >-
+      Allows the caller to submit a job to the cluster. Jobs may gain access
+      to the cluster's service account.
+    links:
+      - https://www.youtube.com/watch?v=kyqeBGNSEIc
+      - https://www.blackhat.com/us-20/briefings/schedule/#lateral-movement-and-privilege-escalation-in-gcp-compromise-any-organization-without-dropping-an-implant-19435
+links:
+  - https://cloud.google.com/dataproc/docs/concepts/overview
+  - https://cloud.google.com/sdk/gcloud/reference/dataproc/clusters
+  - https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters


### PR DESCRIPTION
Adds an important service-account takeover path from https://www.blackhat.com/us-20/briefings/schedule/#lateral-movement-and-privilege-escalation-in-gcp-compromise-any-organization-without-dropping-an-implant-19435.

Also remove duplicate risk in compute.instances.create.