### PR TITLE
risks: Move infra / network deletion to HIGH

### DIFF
--- a/risks/destruction/infra.yml
+++ b/risks/destruction/infra.yml
@@ -1,10 +1,10 @@
 name: Infrastructure destruction
 description: >-
   Allows an attacker to delete infrastructure. May cause
-  interruption of services (including critical operations of
+  interruption of services (including central operations of
   the organization). Can be similar in effect to a denial
   of service.
-score: CRITICAL
+score: HIGH
 mitigations:
   - Define infrastructure as code
 links: []

--- a/risks/destruction/network.yml
+++ b/risks/destruction/network.yml
@@ -4,7 +4,7 @@ description: >-
   routes, VLANs, VPCs and the like). Implies denial-of-service when
   the network hosts a service. Removal of network firewall policies is
   covered by destruction:policy.
-score: CRITICAL
+score: HIGH
 mitigations:
   - Network redundancy
 links: []


### PR DESCRIPTION
We're moving DOS-type risks away from CRITICAL for better prioritization. In keeping with this, move infra + network deletion risks to HIGH.

Note that we should explicitly label deletion of infrastructure that holds data with destruction:data to keep its criticality.