### PR TITLE
Remove cloudfunctions takeover vulnerabilities and explain pubsub topic deletion vulnerability

### DIFF
--- a/services/gcp/cloudfunctions/functions.yml
+++ b/services/gcp/cloudfunctions/functions.yml
@@ -52,19 +52,11 @@ privileges:
       Also allows for DOS via spamming executions and data injection via execution with fake parameters.
   create:
     risks:
-      - discovery:account
-      - discovery:infra
-      - discovery:data
-      - exfiltration:data
-      - takeover:account
       - impact:spend
       - impact:hijack
     notes: >-
       Creating a cloud function requires permissions on the cloud functions runtime service account.
-      It then allows you to export credentials to the service account.
-      Risks also require the sourceCodeSet permission.
     links:
-      - https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/
       - https://cloud.google.com/functions/docs/calling
       - https://cloud.google.com/functions/docs/reference/iam/roles#additional-configuration
   delete:
@@ -76,29 +68,16 @@ privileges:
       - impact:encryption
       - impact:dos
       - impact:spend
-      - impact:hijack
-      - discovery:account
-      - discovery:infra
-      - discovery:data
-      - exfiltration:data
-      - takeover:account
     notes: >-
-      Allows for updating ingress and egress network traffic settings as well as updating encryption keys 
-      Additionally includes the same set of risks as create when the user also has sourceCodeSet permissions.
+      Allows for updating ingress and egress network traffic settings as well as updating encryption keys
   sourceCodeSet:
     risks:
       - impact:dos
       - impact:manipulation
       - impact:spend
       - impact:hijack
-      - discovery:account
-      - discovery:infra
-      - discovery:data
-      - exfiltration:data
-      - takeover:account
     notes: >-
       Includes DOS, data manipulation, spend, and hijack risks.
-      Additionally includes the same set of risks as create when the user also has update permissions.
   getIamPolicy:
     risks: [discovery:policy, discovery:account]
   setIamPolicy:

--- a/services/gcp/cloudfunctions/functions.yml
+++ b/services/gcp/cloudfunctions/functions.yml
@@ -56,7 +56,10 @@ privileges:
       - impact:hijack
     notes: >-
       Creating a cloud function requires permissions on the cloud functions runtime service account.
+      Includes a vulnerability where the user can export service account credentials, but exploiting this 
+      vulnerability requires the user to already have iam.serviceAccounts.actAs on the target service account.
     links:
+      - https://rhinosecuritylabs.com/gcp/privilege-escalation-google-cloud-platform-part-1/
       - https://cloud.google.com/functions/docs/calling
       - https://cloud.google.com/functions/docs/reference/iam/roles#additional-configuration
   delete:

--- a/services/gcp/pubsub/topics.yml
+++ b/services/gcp/pubsub/topics.yml
@@ -12,6 +12,9 @@ privileges:
     scope: LOW
   delete:
     risks: [impact:dos, destruction:data]
+    notes: >-
+      This will delete any messages retained in the Pub/Sub topic. Depending on the configuration, this could be 
+      up to 31 days of messages.
   detachSubscription:
     risks: [impact:dos]
   get:


### PR DESCRIPTION
Remove cloudfunctions takeover vulns since they require iam.serviceAccounts.actAs to execute