### PR TITLE
Add explanation and reference for compute.instance.stop data:destruction

### DIFF
--- a/services/gcp/compute/instances.yml
+++ b/services/gcp/compute/instances.yml
@@ -308,7 +308,7 @@ privileges:
   stop:
     risks: [destruction:data, impact:dos]
     notes: >-
-      Stopping instances with local SSD will result in data loss if the command is issued where the `discard-local-ssd` flag is not provided or false.
+      Stopping instances with local SSD will result in data loss if the command is issued without the `discard-local-ssd` flag set to false.
     mitigation: >-
       To prevent data loss, move the data from the ephemeral storage to a persistent storage.
     links:

--- a/services/gcp/compute/instances.yml
+++ b/services/gcp/compute/instances.yml
@@ -307,6 +307,13 @@ privileges:
       The specified disk encryption key must be already known.
   stop:
     risks: [destruction:data, impact:dos]
+    notes: >-
+      Stopping instances with local SSD will result in data loss if the command is issued where the `discard-local-ssd` flag is not provided or false.
+    mitigation: >-
+      To prevent data loss, move the data from the ephemeral storage to a persistent storage.
+    links:
+      - https://cloud.google.com/sdk/gcloud/reference/compute/instances/stop
+      - https://cloud.google.com/compute/docs/disks/local-ssd#local_ssd_performance
   suspend:
     risks: [impact:dos]
     notes: >-

--- a/services/gcp/compute/instances.yml
+++ b/services/gcp/compute/instances.yml
@@ -308,7 +308,8 @@ privileges:
   stop:
     risks: [destruction:data, impact:dos]
     notes: >-
-      Stopping instances with local SSD will result in data loss if the command is issued without the `discard-local-ssd` flag set to false.
+      Stopping instances with local SSD will delete the disk and result in data loss if the command is issued without the `discard-local-ssd=false`.
+      Instances with persistent storage are not impacted.
     mitigation: >-
       To prevent data loss, move the data from the ephemeral storage to a persistent storage.
     links:

--- a/services/gcp/compute/instances.yml
+++ b/services/gcp/compute/instances.yml
@@ -311,7 +311,7 @@ privileges:
       Stopping instances with local SSD will delete the disk and result in data loss if the command is issued without the `discard-local-ssd=false`.
       Instances with persistent storage are not impacted.
     mitigation: >-
-      To prevent data loss, move the data from the ephemeral storage to a persistent storage.
+      To prevent data loss, move the data from ephemeral storage to persistent storage.
     links:
       - https://cloud.google.com/sdk/gcloud/reference/compute/instances/stop
       - https://cloud.google.com/compute/docs/disks/local-ssd#local_ssd_performance


### PR DESCRIPTION
Added explanation for why compute.instances.stop privilege leads to data destruction with explanation and reference to the documentation. 