### PR TITLE
secrets: Fix risks

### DIFF
--- a/risks/exfiltration/crypto.yml
+++ b/risks/exfiltration/crypto.yml
@@ -1,7 +1,8 @@
 name: Cryptographic exfiltration
 description: >-
-  Allows an attacker to export cryptographic material from a system,
-  including secret keys.
+  Allows an attacker to export cryptographic material from a system.
+  Implies "Account Takeover" when the cryptographic material is an
+  account credential.
 score: CRITICAL
 mitigations:
   - Rotate credentials

--- a/services/gcp/container/secrets.yml
+++ b/services/gcp/container/secrets.yml
@@ -28,8 +28,8 @@ privileges:
     risks:
       - discovery:data
       - discovery:infra
-      - escalation:lateral
-      - escalation:privilege
+      - exfiltration:crypto
+      - exfiltration:data
     notes: >-
       By default, secrets are stored unencrypted in Kubernetes, and anyone who can read the secret
       has access to its contents.
@@ -37,8 +37,8 @@ privileges:
     risks:
       - discovery:data
       - discovery:infra
-      - escalation:lateral
-      - escalation:privilege
+      - exfiltration:crypto
+      - exfiltration:data
     notes: >-
       List all secrets in a specific namespace. Listing also allows reading the data field of each secret.
   update:

--- a/services/gcp/secretmanager/locations.yml
+++ b/services/gcp/secretmanager/locations.yml
@@ -1,6 +1,6 @@
 name: Secret Manager Locations
 description: >-
-  Infrastructure regions available for  Secret Manager resources
+  Infrastructure regions available for Secret Manager resources
 scope: PUBLIC
 notes: >-
   This resource contains public information about Google's location offerings for Secret Manager

--- a/services/gcp/secretmanager/versions.yml
+++ b/services/gcp/secretmanager/versions.yml
@@ -9,11 +9,11 @@ notes: >-
   extremely sensitive data.
 privileges:
   access:
-    risks: [escalation:lateral]
+    risks:
+      - exfiltration:crypto
+      - exfiltration:data
     notes: >-
-      Escalation possibilities depend on the contents of secrets inside
-      the Secret Manager, but for most systems this will include at
-      least some opportunities for lateral escalation.
+      Gives direct read access to secrets data (which often include keys and tokens).
   add:
     risks: [impact:dos]
     notes: >-


### PR DESCRIPTION
Unify secrets exploits behind exfiltration:crypto (which implies account escalation already when crypto material is an account key).