### PR TITLE
Remove destruction:data risk from GCloud container update and delete operations

### DIFF
--- a/services/gcp/container/daemonSets.yml
+++ b/services/gcp/container/daemonSets.yml
@@ -22,7 +22,6 @@ privileges:
   delete:
     risks:
       - destruction:infra
-      - destruction:data
       - destruction:logs
     notes: >-
       Deleting a DaemonSets deletes its pods and ephemeral volumes. Logs of the deleted pods disappear
@@ -50,7 +49,6 @@ privileges:
       Allows listing all ReplicaSets in a namespace.
   update:
     risks:
-      - destruction:data
       - destruction:infra
       - destruction:network
       - escalation:lateral

--- a/services/gcp/container/deployments.yml
+++ b/services/gcp/container/deployments.yml
@@ -33,7 +33,6 @@ privileges:
   delete:
     risks:
       - destruction:infra
-      - destruction:data
       - destruction:logs
     notes: >-
       Deleting a Deployment deletes its pods and ephemeral volumes. Persistent Volumes
@@ -83,7 +82,6 @@ privileges:
       - https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#checking-rollout-history-of-a-deployment
   update:
     risks:
-      - destruction:data
       - destruction:infra
       - destruction:network
       - escalation:lateral
@@ -98,7 +96,6 @@ privileges:
       other Kubernetes workloads. Also, persistent volumes may be attached to the Pods, which may provide access to sensitive data.
   updateScale:
     risks:
-      - destruction:data
       - destruction:infra
       - impact:hijack
       - impact:spend

--- a/services/gcp/container/jobs.yml
+++ b/services/gcp/container/jobs.yml
@@ -29,7 +29,6 @@ privileges:
   delete:
     risks:
       - destruction:infra
-      - destruction:data
       - destruction:logs
     notes: >-
       Deleting a Job deletes its pods and ephemeral volumes. Persistent Volumes

--- a/services/gcp/container/pods.yml
+++ b/services/gcp/container/pods.yml
@@ -33,7 +33,6 @@ privileges:
   delete:
     risks:
       - destruction:infra
-      - destruction:data
       - destruction:logs
     scope: MEDIUM
     notes: >-

--- a/services/gcp/container/replicaSets.yml
+++ b/services/gcp/container/replicaSets.yml
@@ -25,7 +25,6 @@ privileges:
   delete:
     risks:
       - destruction:infra
-      - destruction:data
       - destruction:logs
     notes: >-
       Deleting a ReplicaSet deletes its pods and ephemeral volumes. PersistentVolumes
@@ -63,7 +62,6 @@ privileges:
       Allows listing all ReplicaSets in a namespace.
   update:
     risks:
-      - destruction:data
       - destruction:infra
       - destruction:network
       - escalation:lateral
@@ -79,7 +77,6 @@ privileges:
       Also, persistent volumes may be attached to the Pods, which may provide access to sensitive data.
   updateScale:
     risks:
-      - destruction:data
       - destruction:infra
       - impact:hijack
       - impact:spend

--- a/services/gcp/container/statefulSets.yml
+++ b/services/gcp/container/statefulSets.yml
@@ -22,7 +22,6 @@ privileges:
   delete:
     risks:
       - destruction:infra
-      - destruction:data
       - destruction:logs
     notes: >-
       Deleting a DaemonSets deletes its pods and ephemeral volumes. Persistent Volumes are retained.
@@ -62,7 +61,6 @@ privileges:
       Allows listing all StatefulSets in a namespace.
   update:
     risks:
-      - destruction:data
       - destruction:infra
       - destruction:network
       - escalation:lateral
@@ -78,7 +76,6 @@ privileges:
       Also, persistent volumes may be attached to the Pods, which may provide access to sensitive data.
   updateScale:
     risks:
-      - destruction:data
       - destruction:infra
       - impact:hijack
       - impact:spend


### PR DESCRIPTION
These permissions allow only the deletion of ephemeral volumes, which typically do not store data that users would associate with a data destruction risk. Persistent volumes are retained. This was already explained in the notes.