### PR TITLE
gcp: Annotate iam.serviceAccounts.getAccessToken

### DIFF
--- a/services/gcp/iam/serviceAccounts.yml
+++ b/services/gcp/iam/serviceAccounts.yml
@@ -19,6 +19,9 @@ privileges:
     risks: [discovery:infra]
   getAccessToken:
     risks: [escalation:privilege]
+    notes: >-
+      By default, the generated access token only persists for an hour. Longer access times (up to 12 hours) can be configured via
+      the constraints/iam.allowServiceAccountCredentialLifetimeExtension organization policy.
   getIamPolicy:
     risks: [discovery:policy, discovery:account]
   getOpenIdToken:


### PR DESCRIPTION
Adds some additional insight into token lifetime.