### PR TITLE
Updated risks for bigquery.models.updateMetadata 

### DIFF
--- a/risks/destruction/artifact.yml
+++ b/risks/destruction/artifact.yml
@@ -1,0 +1,6 @@
+name: Artifact destruction
+description: |
+  Allows an attacker to delete artifacts like machine learning models.
+score: MEDIUM
+mitigations:
+links:

--- a/services/gcp/bigquery/models.yml
+++ b/services/gcp/bigquery/models.yml
@@ -28,8 +28,10 @@ privileges:
     risks: []
     notes: 'From Google: "Update model data.". Appears unused.'
   updateMetadata:
-    risks: [escalation:data, destruction:data, destruction:infra]
-    notes: 'From Google: "Update model metadata.". Allows a user to modify encryption keys or change model expiration intervals.'
+    risks: [destruction:artifact]
+    notes: >-
+      'From Google: "Update model metadata.". Allows users to update description, labels and change model expiration time.'
+      Allows users to destroy a model by setting its expiration to 0.
     links:
       - https://cloud.google.com/bigquery/docs/updating-model-metadata
       - https://cloud.google.com/bigquery/docs/reference/rest/v2/models/patch


### PR DESCRIPTION
replace risks of destruction infra, data with artifact as original data is not deleted.
Adds destruction of artifacts