### PR TITLE
Remove escalation:privilege from container permissions

### DIFF
--- a/services/gcp/container/clusterRoleBindings.yml
+++ b/services/gcp/container/clusterRoleBindings.yml
@@ -9,12 +9,11 @@ notes: >-
   assigned to principal via a ClusterRoleBinding.
 privileges:
   create:
-    risks: [escalation:privilege]
-    scope: MEDIUM
+    risks: []
     notes: >-
       Kubernetes does not allow the creation or update of a ClusterRoleBinding unless at least one of the following two conditions is met:
       1) the caller has the permission it is granting
-      2) the caller has the `containers.clusterRoles.bind` permission
+      2) the caller has the `container.clusterRoles.bind` permission
     links:
       - https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update
   delete:
@@ -30,9 +29,9 @@ privileges:
     notes: >-
       List all ClusterRoleBindings within a namespace
   update:
-    risks: [escalation:privilege]
+    risks: []
     scope: MEDIUM
     notes: >-
       Kubernetes does not allow the creation or update of a ClusterRoleBinding unless one of the following two conditions are met:
       1) the caller has the permission it is granting
-      2) the caller has the `containers.clusterRoles.bind` permission
+      2) the caller has the `container.clusterRoles.bind` permission

--- a/services/gcp/container/clusterRoles.yml
+++ b/services/gcp/container/clusterRoles.yml
@@ -11,16 +11,18 @@ privileges:
   bind:
     risks: [escalation:privilege]
     notes: >-
-      Kubernetes does not allow the creation or update of a ClusterRoleBinding if that grants permissions
-      the caller user does not already have. However, the `bind` permission allows this action.
+      Allows escalating the current or other users' permissions by binding a ClusterRole to them. 
+      Also requires the `container.clusterRoleBindings.create` or `container.clusterRoleBindings.update` permission.
     links:
       - https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update
   create:
     risks: []
-    scope: LOW
     notes: >-
       ClusterRoles are only definitions of permissions. A role does not take effect unless
       assigned to principal via a ClusterRoleBinding.
+      Kubernetes does not allow the creation or update of a ClusterRole unless one of the following two conditions are met:
+      1) the caller already has the permissions contained in the role
+      2) the caller has the `container.clusterRoles.escalate` permission
   delete:
     risks: [destruction:policy]
     notes: >-
@@ -28,7 +30,8 @@ privileges:
   escalate:
     risks: [escalation:privilege]
     notes: >-
-      Allows escalating the current or other users' permissions via a ClusterRole creation or update.
+      Allows escalating the current or other users' permissions by creating a new ClusterRole or updating an existing ClusterRole.
+      Also requires the `container.clusterRoles.create` or `container.clusterRoles.update` permission.
     links:
       - https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-creation-or-update
   get:
@@ -40,10 +43,8 @@ privileges:
     notes: >-
       List all ClusterRoles
   update:
-    risks: [escalation:privilege]
-    scope: MEDIUM
+    risks: []
     notes: >-
-      ClusterRole updates are dangerous because the updated role may already be assigned to principals,
-      leading to privilege escalation. However, the Kubernetes API prevents escalating privileges of
-      the current or another user via a ClusterRole creation or update, unless the user already has 
-      the permission, or has the `escalate` permission.
+      Kubernetes does not allow the creation or update of a ClusterRole unless one of the following two conditions are met:
+      1) the caller already has the permissions contained in the role
+      2) the caller has the `container.clusterRoles.escalate` permission

--- a/services/gcp/container/roleBindings.yml
+++ b/services/gcp/container/roleBindings.yml
@@ -9,12 +9,11 @@ notes: >-
   assigned to principal via a RoleBinding.
 privileges:
   create:
-    risks: [escalation:privilege]
-    scope: MEDIUM
+    risks: []
     notes: >-
       Kubernetes does not allow the creation or update of a RoleBinding unless at least one of the following two conditions is met:
       1) the caller has the permission it is granting
-      2) the caller has the `containers.roles.bind` permission
+      2) the caller has the `container.roles.bind` permission
     links:
       - https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update
   delete:
@@ -30,9 +29,8 @@ privileges:
     notes: >-
       List all RoleBindings within a namespace
   update:
-    risks: [escalation:privilege]
-    scope: MEDIUM
+    risks: []
     notes: >-
       Kubernetes does not allow the creation or update of a RoleBinding unless one of the following two conditions are met:
       1) the caller has the permission it is granting
-      2) the caller has the `containers.roles.bind` permission
+      2) the caller has the `container.roles.bind` permission

--- a/services/gcp/container/roles.yml
+++ b/services/gcp/container/roles.yml
@@ -11,8 +11,8 @@ privileges:
   bind:
     risks: [escalation:privilege]
     notes: >-
-      Kubernetes does not allow the creation or update of a RoleBinding if that grants permissions
-      the caller user does not already have. However, the `bind` permission allows this action.
+      Allows escalating the current or other users' permissions by binding a Role to them. 
+      Also requires the `container.roleBindings.create` or `container.roleBindings.update` permission.
     links:
       - https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-binding-creation-or-update
   create:
@@ -20,6 +20,9 @@ privileges:
     notes: >-
       Roles are only definitions of permissions. A role does not take effect unless
       assigned to principal via a RoleBinding.
+      Kubernetes does not allow the creation or update of a Role unless one of the following two conditions are met:
+      1) the caller already has the permissions contained in the role
+      2) the caller has the `container.roles.escalate` permission
   delete:
     risks: [destruction:policy]
     notes: >-
@@ -27,7 +30,8 @@ privileges:
   escalate:
     risks: [escalation:privilege]
     notes: >-
-      Allows escalating the current or other users' permissions via a Role creation or update.
+      Allows escalating the current or other users' permissions by creating a new Role or updating an existing Role.
+      Also requires the `container.roles.create` or `container.roles.update` permission.
     links:
       - https://kubernetes.io/docs/reference/access-authn-authz/rbac/#restrictions-on-role-creation-or-update
   get:
@@ -39,10 +43,8 @@ privileges:
     notes: >-
       List all roles within a namespace
   update:
-    risks: [escalation:privilege]
-    scope: MEDIUM
+    risks: []
     notes: >-
-      Role updates are dangerous because the updated role may already be assigned to principals,
-      leading to privilege escalation. However, the Kubernetes API prevents escalating privileges of
-      the current or another user via a Role creation or update, unless the user already has 
-      the permission, or has the `escalate` permission.
+      Kubernetes does not allow the creation or update of a Role unless one of the following two conditions are met:
+      1) the caller already has the permissions contained in the role
+      2) the caller has the `container.roles.escalate` permission

--- a/services/gcp/container/serviceAccounts.yml
+++ b/services/gcp/container/serviceAccounts.yml
@@ -24,9 +24,10 @@ privileges:
     notes: >-
       Allows sending a TokenRequest to the API server. This request issues a new token and binds
       the token to a service account. The token is also returned to the caller, allowing it to act as 
-      the service account using that token.
+      the service account bound to that token.
     links:
       - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#tokenrequestspec-v1-authentication-k8s-io
+      - https://securitylabs.datadoghq.com/articles/kubernetes-tokenrequest-api/
   delete:
     risks: [destruction:infra]
     notes: >-


### PR DESCRIPTION
Removes escalation:privilege permissions from role/clusterRole and roleBinding/clusterRoleBinding create and update permissions since additional conditions must be satisfied that mitigate escalation risk.