### PR TITLE
Review "escalation:privilege" and "escalation:lateral" risks

### DIFF
--- a/services/gcp/bigquery/connections.yml
+++ b/services/gcp/bigquery/connections.yml
@@ -40,7 +40,7 @@ privileges:
         - The attacker must already have read access to the target data system, or have a mechanism to give
           the connection read access to the target data system
         - The attacker can then use this permission to run queries against the connection
-      In general, therefore, exfiltration is only possible when the attacker already otherwise has access ot the
+      In general, therefore, exfiltration is only possible when the attacker already otherwise has access to the
       target system.
 links:
   - https://cloud.google.com/bigquery/docs/access-control

--- a/services/gcp/cloudbuild/builds.yml
+++ b/services/gcp/cloudbuild/builds.yml
@@ -10,7 +10,7 @@ privileges:
     notes: >-
       This allows the user to both approve or deny an existing build.
   create:
-    risks: [impact:spend, impact:dos, escalation:privilege]
+    risks: [impact:spend, impact:dos, escalation:lateral]
     notes: >-
       This permission allows users to run builds as the Cloud Build service account. This can allow the user to have escalated build-time privileges.
       Google explicitly cautions against granting this permission for that reason.
@@ -25,4 +25,5 @@ privileges:
 links:
   - https://cloud.google.com/build/docs/iam-roles-permissions
   - https://cloud.google.com/build/docs/overview#how_builds_work
+  - https://cloud.google.com/build/docs/cloud-build-service-account#default_permissions_of_service_account
   - https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#Build

--- a/services/gcp/container/clusterRoles.yml
+++ b/services/gcp/container/clusterRoles.yml
@@ -9,7 +9,7 @@ notes: >-
   assigned to principal via a ClusterRoleBinding.
 privileges:
   bind:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral, escalation:privilege]
     notes: >-
       Allows escalating the current or other users' permissions by binding a ClusterRole to them. 
       Also requires the `container.clusterRoleBindings.create` or `container.clusterRoleBindings.update` permission.
@@ -28,7 +28,7 @@ privileges:
     notes: >-
       ClusterRoles that are attached to principals via a ClusterRoleBinding can be deleted in Kubernetes.
   escalate:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral, escalation:privilege]
     notes: >-
       Allows escalating the current or other users' permissions by creating a new ClusterRole or updating an existing ClusterRole.
       Also requires the `container.clusterRoles.create` or `container.clusterRoles.update` permission.

--- a/services/gcp/container/clusterRoles.yml
+++ b/services/gcp/container/clusterRoles.yml
@@ -9,7 +9,7 @@ notes: >-
   assigned to principal via a ClusterRoleBinding.
 privileges:
   bind:
-    risks: [escalation:lateral, escalation:privilege]
+    risks: [escalation:privilege]
     notes: >-
       Allows escalating the current or other users' permissions by binding a ClusterRole to them. 
       Also requires the `container.clusterRoleBindings.create` or `container.clusterRoleBindings.update` permission.

--- a/services/gcp/container/roles.yml
+++ b/services/gcp/container/roles.yml
@@ -9,7 +9,7 @@ notes: >-
   assigned to principal via a RoleBinding.
 privileges:
   bind:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral, escalation:privilege]
     notes: >-
       Allows escalating the current or other users' permissions by binding a Role to them. 
       Also requires the `container.roleBindings.create` or `container.roleBindings.update` permission.
@@ -28,7 +28,7 @@ privileges:
     notes: >-
       Roles that are attached to principals via a RoleBinding can be deleted in Kubernetes.
   escalate:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral, escalation:privilege]
     notes: >-
       Allows escalating the current or other users' permissions by creating a new Role or updating an existing Role.
       Also requires the `container.roles.create` or `container.roles.update` permission.

--- a/services/gcp/container/serviceAccounts.yml
+++ b/services/gcp/container/serviceAccounts.yml
@@ -20,7 +20,7 @@ privileges:
       Creating a service account by itself does not represent a security risk.
       Service accounts need to be granted permissions via Roles.
   createToken:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral, escalation:privilege]
     notes: >-
       Allows sending a TokenRequest to the API server. This request issues a new token and binds
       the token to a service account. The token is also returned to the caller, allowing it to act as 

--- a/services/gcp/container/serviceAccounts.yml
+++ b/services/gcp/container/serviceAccounts.yml
@@ -20,7 +20,7 @@ privileges:
       Creating a service account by itself does not represent a security risk.
       Service accounts need to be granted permissions via Roles.
   createToken:
-    risks: [escalation:lateral, escalation:privilege]
+    risks: [escalation:lateral]
     notes: >-
       Allows sending a TokenRequest to the API server. This request issues a new token and binds
       the token to a service account. The token is also returned to the caller, allowing it to act as 

--- a/services/gcp/iam/roles.yml
+++ b/services/gcp/iam/roles.yml
@@ -17,7 +17,12 @@ privileges:
     notes: >-
       Deleting a custom role is possible even when it's present in bindings. The bindings remain, but are ineffectual.
   update:
-    risks: [escalation:privilege, impact:access]
+    risks: [escalation:lateral, escalation:privilege, impact:access]
+    notes: >-
+      Only custom roles can be updated. An update automatically grants additional access for principals to resources 
+      that the role is bound to. An attacker is able to grant additional permissions to a role they already have.
+      Note that permissions are inherited by child resources. For example, updating role bound to a project can grant
+      permissions on new services and new resources.
   get:
     risks: [discovery:policy]
   list:

--- a/services/gcp/iam/roles.yml
+++ b/services/gcp/iam/roles.yml
@@ -17,7 +17,7 @@ privileges:
     notes: >-
       Deleting a custom role is possible even when it's present in bindings. The bindings remain, but are ineffectual.
   update:
-    risks: [escalation:lateral, escalation:privilege, impact:access]
+    risks: [escalation:privilege, impact:access]
     notes: >-
       Only custom roles can be updated. An update automatically grants additional access for principals to resources 
       that the role is bound to. An attacker is able to grant additional permissions to a role they already have.

--- a/services/gcp/iam/serviceAccountKeys.yml
+++ b/services/gcp/iam/serviceAccountKeys.yml
@@ -18,7 +18,7 @@ privileges:
     notes: >-
       This leads to a DOS in any application that is using the service account key for authentication.
   enable:
-    risks: [escalation:privilege, persistence:account]
+    risks: [escalation:lateral, persistence:account]
     notes: >-
       This can allow a privilege escalation if the attacker is able to gain access to a disabled service account key.
   get:

--- a/services/gcp/iam/serviceAccounts.yml
+++ b/services/gcp/iam/serviceAccounts.yml
@@ -6,7 +6,7 @@ notes: >-
   Many of these permissions are extremely sensitive, because service accounts are frequently overprovisioned. A user with access to a service account effectively has access to all permissions the service account has, so broad access to service accounts can allow users to gain unintended access.
 privileges:
   actAs:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral]
   create:
     risks: [impact:spend, persistence:account]
   delete:
@@ -18,26 +18,26 @@ privileges:
   get:
     risks: [discovery:infra]
   getAccessToken:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral]
     notes: >-
       By default, the generated access token only persists for an hour. Longer access times (up to 12 hours) can be configured via
       the constraints/iam.allowServiceAccountCredentialLifetimeExtension organization policy.
   getIamPolicy:
     risks: [discovery:policy, discovery:account]
   getOpenIdToken:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral]
   implicitDelegation:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral]
     notes: >-
       Implicit delegation allows you to chain service account access token requests. This permission on a service account gives the user access to creating access tokens on any service accounts that service account has access to.
   setIamPolicy:
     risks: [escalation:privilege, impact:access, destruction:policy]
   signBlob:
-    risks: [escalation:privilege, impact:manipulation]
+    risks: [escalation:lateral, impact:manipulation]
     notes: >-
       Allows for signing of arbitrarily payloads. Can be used for escalation by signing an access token request.
   signJwt:
-    risks: [escalation:privilege]
+    risks: [escalation:lateral]
     notes: >-
       Can be used for escalation by signing an access token request.
   list:

--- a/services/gcp/pubsub/topics.yml
+++ b/services/gcp/pubsub/topics.yml
@@ -30,12 +30,9 @@ privileges:
   update:
     risks: [impact:dos]
   updateTag:
-    risks: [escalation:privilege]
+    risks: []
     notes: >-
-      A common use case of tag bindings is for use in IAM policy conditions. If the user has any
-      policies that use tag bindings to enforce conditions, creating a tag on a resource allows them
-      to escalate their access to that resource. Also requires getIamPolicy or knowledge of the IAM
-      policy from some other means.
+      This IAM permission doesn't have a corresponding API method. It's unclear what this permission is for.
 links:
   - https://cloud.google.com/pubsub/docs/create-topic
   - https://cloud.google.com/pubsub/docs/access-control


### PR DESCRIPTION
The principle behind this review:
- `escalation:privilege` allows users to access more sensitive permissions within the same service
- `escalation:lateral` allows users to gain access to new services. This is typically via service account impersonation, either direct or indirect (e.g. CloudBuild)

The net result is that some permissions are re-categorized from `escalation:privilege` to `escalation:lateral`, and some permission gained `escalation:lateral` to have both.