### PR TITLE
Privilege updates while validating basic roles

### DIFF
--- a/services/gcp/apikeys/keys.yml
+++ b/services/gcp/apikeys/keys.yml
@@ -1,0 +1,40 @@
+name: Google API Keys
+description: >-
+  An API Key can be used to authenticate to supported Google REST APIs. Not all Google APIs supported authneitcation via API key.
+scope: CRITICAL
+notes: >-
+  Because API keys do not provide a principal or check any additional authorization information, an individual that
+  gains access to an API key will be able to use it to call supported Google APIs without detection.
+privileges:
+  create:
+    risks: [impact:spend, impact:consumption]
+    notes: >-
+      There is a maximum of 300 API keys per project that cannot be increased.
+      The key creation API response does not actually return the key.
+  delete:
+    risks: [impact:dos]
+  get:
+    risks: [discovery:infra]
+    notes: >-
+      Does not include the key value.
+  getKeyString:
+    risks: [escalation:privilege]
+  list:
+    risks: [discovery:infra]
+    notes: >-
+      Does not include the key value.
+  lookup:
+    risks: []
+    notes: >-
+      This is used to look-up the key from the key value. 
+      It is not useful unless someone already has the key value.
+  undelete:
+    risks: [impact:spend, impact:consumption]
+  update:
+    risks: [impact:dos, desturction:defense]
+    notes: >-
+      Can be used to add or remove restrictions (API restrictions or application restrictions) on how the key can be used.
+links:
+  - https://cloud.google.com/docs/authentication/api-keys
+  - https://cloud.google.com/api-keys/docs/reference/rest/v2/keys
+  - https://cloud.google.com/api-keys/docs/overview

--- a/services/gcp/apikeys/keys.yml
+++ b/services/gcp/apikeys/keys.yml
@@ -1,6 +1,6 @@
 name: Google API Keys
 description: >-
-  An API Key can be used to authenticate to supported Google REST APIs. Not all Google APIs supported authneitcation via API key.
+  An API Key can be used to authenticate to supported Google REST APIs. Not all Google APIs support authentication via API key.
 scope: CRITICAL
 notes: >-
   Because API keys do not provide a principal or check any additional authorization information, an individual that
@@ -31,7 +31,7 @@ privileges:
   undelete:
     risks: [impact:spend, impact:consumption]
   update:
-    risks: [impact:dos, desturction:defense]
+    risks: [impact:dos, destruction:defense]
     notes: >-
       Can be used to add or remove restrictions (API restrictions or application restrictions) on how the key can be used.
 links:

--- a/services/gcp/compute/images.yml
+++ b/services/gcp/compute/images.yml
@@ -34,15 +34,11 @@ privileges:
     notes: >-
       The customer managed key ids, configured for the image, are be returned in the api. No raw encryption keys are exposed.
   getFromFamily:
-    risks: [exfiltration:crypto]
-    notes: >-
-      Potentially gives access to raw encryption keys.
+    risks: [discovery:infra]
   getIamPolicy:
     risks: [discovery:account, discovery:policy]
   list:
-    risks: [exfiltration:crypto]
-    notes: >-
-      Potentially gives access to raw encryption keys.
+    risks: [discovery:infra]
   listEffectiveTags:
     risks: [discovery:policy]
   listTagBindings:


### PR DESCRIPTION
While validating basic roles, I noticed:
- viewer had crypto exfil, which I doubted, so I checked the API response for the compute images get/list methods, and it does not include the raw key. it only includes a sha256 hash of the key. (response included below)
- apikeys sounded sensitive and was in the no risks section, so I added it



Image API response 
```
{
  "kind": "compute#imageList",
  "id": "projects/still-girder-340817/global/images",
  "items": [
    {
      "kind": "compute#image",
      "id": "1190729280232419561",
      "creationTimestamp": "2023-11-03T12:46:15.205-07:00",
      "name": "image-1",
      "sourceType": "RAW",
      "status": "PENDING",
      "diskSizeGb": "10",
      "sourceDisk": "https://www.googleapis.com/compute/v1/projects/still-girder-340817/zones/us-central1-a/disks/permz-test-instance-1",
      "sourceDiskId": "1419745191353413149",
      "licenses": [
        "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-11-bullseye"
      ],
      "imageEncryptionKey": {
        "sha256": "esTuF7d4eatX4cnc4JsiEiaI+Rff78JgPhA/v1zxX9E="
      },
      "selfLink": "https://www.googleapis.com/compute/v1/projects/still-girder-340817/global/images/image-1",
      "labelFingerprint": "42WmSpB8rSM=",
      "guestOsFeatures": [
        {
          "type": "UEFI_COMPATIBLE"
        },
        {
          "type": "VIRTIO_SCSI_MULTIQUEUE"
        },
        {
          "type": "GVNIC"
        },
        {
          "type": "SEV_CAPABLE"
        }
      ],
      "licenseCodes": [
        "3853522013536123851"
      ],
      "architecture": "X86_64"
    }
  ],
  "selfLink": "https://www.googleapis.com/compute/v1/projects/still-girder-340817/global/images"
}

```
