### PR TITLE
Add catalog project to deploy pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,9 @@ jobs:
           - project_number: "228132571547"
             environment: prod
             project_id: p0-prod
+          - project_number: "951348949086"
+            environment: catalog
+            project_id: p0-catalog
     steps:
       - id: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Adds the p0-catalog project to the deploy pipeline. A follow-up will remove the other project once we switched our services to read from the new project.