### PR TITLE
CD: load BigQuery without --auto-detect

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,6 +66,6 @@ jobs:
             cat dist/privileges.json | jq -c -r '.gcp[]' > dist/privileges-gcp.jsonl && \
             cat dist/privileges.json | jq -c -r '.aws[]' > dist/privileges-aws.jsonl && \
             gcloud auth login --cred-file $GOOGLE_APPLICATION_CREDENTIALS && \
-            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON --ignore_unknown_values iam_risk_2.privileges-gcp dist/privileges-gcp.jsonl && \
-            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON --ignore_unknown_values iam_risk_2.privileges-aws dist/privileges-aws.jsonl && \
-            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON --ignore_unknown_values iam_risk_2.risks dist/risks.jsonl
+            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON iam_risk_2.privileges-gcp dist/privileges-gcp.jsonl && \
+            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON iam_risk_2.privileges-aws dist/privileges-aws.jsonl && \
+            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON iam_risk_2.risks dist/risks.jsonl

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,6 +66,6 @@ jobs:
             cat dist/privileges.json | jq -c -r '.gcp[]' > dist/privileges-gcp.jsonl && \
             cat dist/privileges.json | jq -c -r '.aws[]' > dist/privileges-aws.jsonl && \
             gcloud auth login --cred-file $GOOGLE_APPLICATION_CREDENTIALS && \
-            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON --autodetect iam_risk_2.privileges-gcp dist/privileges-gcp.jsonl && \
-            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON --autodetect iam_risk_2.privileges-aws dist/privileges-aws.jsonl && \
-            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON --autodetect iam_risk_2.risks dist/risks.jsonl
+            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON --ignore_unknown_values iam_risk_2.privileges-gcp dist/privileges-gcp.jsonl && \
+            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON --ignore_unknown_values iam_risk_2.privileges-aws dist/privileges-aws.jsonl && \
+            bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON --ignore_unknown_values iam_risk_2.risks dist/risks.jsonl

--- a/services/README.md
+++ b/services/README.md
@@ -55,7 +55,7 @@ Each component has the following data:
   - **notes**: If present, any additional notes specific to this privilege; these
     should explain any scope override
   - **links**: If present, an array of additional links
-  - **mitigation**: If present, describes the action(s) that an organization can take to avoid the risks associated with the privilege
+  - **mitigations**: If present, describes the action(s) that an organization can take to avoid the risks associated with the privilege
 - **links**: An array of external-reference URLs
 
 Note that privilege identifiers are determined on a per-service basis from the

--- a/services/README.md
+++ b/services/README.md
@@ -55,6 +55,7 @@ Each component has the following data:
   - **notes**: If present, any additional notes specific to this privilege; these
     should explain any scope override
   - **links**: If present, an array of additional links
+  - **mitigation**: If present, describes the action(s) that an organization can take to avoid the risks associated with the privilege
 - **links**: An array of external-reference URLs
 
 Note that privilege identifiers are determined on a per-service basis from the

--- a/services/gcp/compute/instances.yml
+++ b/services/gcp/compute/instances.yml
@@ -305,8 +305,8 @@ privileges:
     notes: >-
       Stopping instances with local SSD will delete the disk and result in data loss if the command is issued without the `discard-local-ssd=false`.
       Instances with persistent storage are not impacted.
-    mitigation: >-
-      To prevent data loss, move the data from ephemeral storage to persistent storage.
+    mitigations:
+      - To prevent data loss, move the data from ephemeral storage to persistent storage.
     links:
       - https://cloud.google.com/sdk/gcloud/reference/compute/instances/stop
       - https://cloud.google.com/compute/docs/disks/local-ssd#local_ssd_performance

--- a/services/gcp/container/secrets.yml
+++ b/services/gcp/container/secrets.yml
@@ -7,7 +7,7 @@ notes: >-
   By default, secrets are stored unencrypted, and anyone who can read a Secret can read its contents (its `data` field).
   The Secret contents are mounted inside pods as files in the file system. Someone with ability to gain access into a Pod
   may freely read the contents of the secret.
-mitigation: >-
+mitigations:
   - Configure RBAC rules to limit read access to secrets
   - Configure encryption at rest for secrets
   - Use external Secret Providers

--- a/services/gcp/container/secrets.yml
+++ b/services/gcp/container/secrets.yml
@@ -7,7 +7,7 @@ notes: >-
   By default, secrets are stored unencrypted, and anyone who can read a Secret can read its contents (its `data` field).
   The Secret contents are mounted inside pods as files in the file system. Someone with ability to gain access into a Pod
   may freely read the contents of the secret.
-mitigations:
+mitigation: >-
   - Configure RBAC rules to limit read access to secrets
   - Configure encryption at rest for secrets
   - Use external Secret Providers


### PR DESCRIPTION
Replace `--auto-detect` with `--ignore_unknown_values` when loading BQ.
This change works with a predefined BigQuery table schema because it does not replace the already existing schema. The existing `--replace` flag in this case only replaces the data, not the schema. The `--ignore_unknown_values` flag makes the load more resilient against deviations from the table schema.

Also: two privileges contain mitigations: `services/gcp/compute/instances.yml` and `services/gcp/container/secrets.yml`, however the former uses a string `mitigation` field while the latter uses an array `mitigations` field. Settle on the singular form to avoid a conflict with the `mitigations` field of risks, which is also loaded into BQ.