### PR TITLE
cd: Fix upload script

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
       - env:
           SERVICES: aws gcp k8s workspace
         run: |
-          for SERVICE in "${SERVICES}"; do
+          for SERVICE in $(echo "${SERVICES}"); do
             cat dist/privileges.json | jq -c -r ".${SERVICE}[]" > dist/privileges-${SERVICE}.jsonl
             bq load --project_id ${{ matrix.items.project_id }} --replace --source_format NEWLINE_DELIMITED_JSON iam_risk_2.privileges-${SERVICE} dist/privileges-${SERVICE}.jsonl
           done


### PR DESCRIPTION
Variable expansion requires an `echo` to unpack a space-delimited string,
apparently.