### PR TITLE
fix: update semgrep runner from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ name: Semgrep
 jobs:
   semgrep:
     name: Scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
## Summary

- `ubuntu-20.04` GitHub-hosted runners were deprecated and removed in April 2025
- Jobs requesting this label hang indefinitely waiting for a runner that no longer exists
- Updated to `ubuntu-22.04` to restore reliable CI execution

## Test plan

- [ ] Verify the Semgrep workflow runs successfully on this PR without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)