### PR TITLE
Azure: add privilege classifications (batch 7/14)

### DIFF
--- a/services/azure/Microsoft.Network/BastionHosts/setsessionrecordingsasurl.yml
+++ b/services/azure/Microsoft.Network/BastionHosts/setsessionrecordingsasurl.yml
@@ -1,7 +1,7 @@
-name: Bastion Host session recording SAS URL configuration
-description: Sets the SAS URL for the storage location where Bastion session recordings are stored, redirecting where future session recordings are written.
+name: Bastion Host
+description: Azure Bastion is a managed PaaS jump host deployed in a VNet that brokers secure browser-based RDP/SSH connectivity to VMs without exposing public IPs on those VMs.
 scope: HIGH
-notes: Configuration change to the audit/recording pipeline rather than to the Bastion Host's access controls directly.
+notes: A production secure-access entry point into a private network; controlling or observing it affects reachability of all VMs behind it.
 links:
   - https://azure.permissions.cloud/iam/Microsoft.Network
   - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations

--- a/services/azure/Microsoft.Network/BastionHosts/setsessionrecordingsasurl.yml
+++ b/services/azure/Microsoft.Network/BastionHosts/setsessionrecordingsasurl.yml
@@ -1,0 +1,12 @@
+name: Bastion Host session recording SAS URL configuration
+description: Sets the SAS URL for the storage location where Bastion session recordings are stored, redirecting where future session recordings are written.
+scope: HIGH
+notes: Configuration change to the audit/recording pipeline rather than to the Bastion Host's access controls directly.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - destruction:defense
+    notes: Redirecting session recordings to an attacker-controlled or otherwise inaccessible storage location silently defeats the session-recording audit trail, an evasion technique that lets subsequent privileged-session abuse go unrecorded.

--- a/services/azure/Microsoft.Network/applicationGateways.yml
+++ b/services/azure/Microsoft.Network/applicationGateways.yml
@@ -1,0 +1,18 @@
+name: Application Gateway
+description: Azure Application Gateway is a layer-7 (HTTP/HTTPS) load balancer and web-traffic router that terminates TLS, evaluates listener/routing rules, and forwards requests to backend pools; it commonly holds the TLS certificate for the fronted application.
+scope: HIGH
+notes: Sits directly in the path of live production HTTP(S) traffic and frequently terminates TLS for the fronted application; write access lets an attacker redirect or intercept that traffic, including decrypted content. Rated HIGH rather than CRITICAL because impact is scoped to the traffic/applications routed through this specific gateway rather than whole-network segmentation.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  delete:
+    risks:
+      - destruction:network
+      - impact:dos
+    notes: Deletes the application gateway, removing the routing/TLS-termination front end and causing outage for every backend it serves.
+  write:
+    risks:
+      - exfiltration:data
+      - escalation:network
+    notes: Creating or updating listener rules, backend pools, or HTTP settings lets an attacker redirect or intercept live production traffic, including TLS-terminated traffic since the gateway typically holds the bound certificate.

--- a/services/azure/Microsoft.Network/applicationGateways/getListenerCertificateMetadata.yml
+++ b/services/azure/Microsoft.Network/applicationGateways/getListenerCertificateMetadata.yml
@@ -1,0 +1,12 @@
+name: Application Gateway listener certificate metadata
+description: Returns metadata about the TLS certificate bound to an application gateway listener.
+scope: HIGH
+notes: Read-only reconnaissance action inherited from the application gateway's HIGH scope.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - discovery:network
+    notes: Discloses which TLS certificate/domain is bound to a listener, revealing which applications are fronted by the gateway and aiding targeting of a subsequent attack.

--- a/services/azure/Microsoft.Network/applicationSecurityGroups.yml
+++ b/services/azure/Microsoft.Network/applicationSecurityGroups.yml
@@ -1,0 +1,17 @@
+name: Application security group
+description: An Application Security Group (ASG) is a logical grouping of network interfaces (by application role) that can be referenced as the source/destination of NSG rules, instead of explicit IP ranges, to scope firewall rules to a set of VMs.
+scope: HIGH
+notes: An ASG is a perimeter/segmentation control referenced by NSG rules; membership in one determines which firewall rules apply to a given interface, so misuse indirectly controls network access the same way an NSG does. Rated consistent with the other network-segmentation resources documented alongside it.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  delete:
+    risks:
+      - destruction:policy
+      - impact:dos
+    notes: Deleting an ASG invalidates any NSG rule that references it as a source/destination, silently disabling those rules (opening the traffic they were meant to restrict) or breaking rules that were permitting required traffic.
+  write:
+    risks:
+      - escalation:network
+    notes: Creating or updating an ASG definition is a prerequisite for controlling which interfaces inherit the firewall rules written against that group; combined with join rights on member interfaces/rules, it lets an attacker reshape which traffic reaches a given application tier.

--- a/services/azure/Microsoft.Network/applicationSecurityGroups/joinIpConfiguration.yml
+++ b/services/azure/Microsoft.Network/applicationSecurityGroups/joinIpConfiguration.yml
@@ -1,0 +1,12 @@
+name: Application security group
+description: An Application Security Group (ASG) is a logical grouping of network interfaces (by application role) that can be referenced as the source/destination of NSG rules, instead of explicit IP ranges, to scope firewall rules to a set of VMs.
+scope: HIGH
+notes: An ASG is a perimeter/segmentation control referenced by NSG rules; membership in one determines which firewall rules apply to a given interface, so misuse indirectly controls network access the same way an NSG does. Rated consistent with the other network-segmentation resources documented alongside it.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - escalation:network
+    notes: Azure requires this permission on the ASG itself before a principal can add an interface's IP configuration as a member, specifically so that a principal with only narrow "create resource" rights cannot silently opt their own interface into (or leave it out of) the firewall rules that reference this group. Holding join lets an attacker enroll an attacker-controlled interface into a trusted ASG (inheriting the access that ASG's membership grants in NSG rules) or withhold a sanctioned interface from a restrictive ASG, bypassing intended segmentation.

--- a/services/azure/Microsoft.Network/applicationSecurityGroups/joinNetworkSecurityRule.yml
+++ b/services/azure/Microsoft.Network/applicationSecurityGroups/joinNetworkSecurityRule.yml
@@ -1,0 +1,12 @@
+name: Application security group
+description: An Application Security Group (ASG) is a logical grouping of network interfaces (by application role) that can be referenced as the source/destination of NSG rules, instead of explicit IP ranges, to scope firewall rules to a set of VMs.
+scope: HIGH
+notes: An ASG is a perimeter/segmentation control referenced by NSG rules; membership in one determines which firewall rules apply to a given interface, so misuse indirectly controls network access the same way an NSG does. Rated consistent with the other network-segmentation resources documented alongside it.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - escalation:network
+    notes: Azure requires this permission on the ASG itself before a principal can reference it as the source/destination of an NSG security rule, specifically so that a principal with only narrow rule-authoring rights cannot silently scope a rule to a group they don't control. Holding join lets an attacker wire an attacker-controlled ASG into a security rule (or wire a sanctioned ASG into an attacker-authored rule) to open or evade intended firewall segmentation.

--- a/services/azure/Microsoft.Network/applicationSecurityGroups/listAddressPrefixSets.yml
+++ b/services/azure/Microsoft.Network/applicationSecurityGroups/listAddressPrefixSets.yml
@@ -1,0 +1,12 @@
+name: Application security group
+description: An Application Security Group (ASG) is a logical grouping of network interfaces (by application role) that can be referenced as the source/destination of NSG rules, instead of explicit IP ranges, to scope firewall rules to a set of VMs.
+scope: HIGH
+notes: An ASG is a perimeter/segmentation control referenced by NSG rules; membership in one determines which firewall rules apply to a given interface, so misuse indirectly controls network access the same way an NSG does. Rated consistent with the other network-segmentation resources documented alongside it.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - discovery:network
+    notes: Lists the resolved address prefixes backing the ASG's members, revealing the actual IP ranges that firewall rules referencing this group apply to; aids reconnaissance of the network segmentation topology ahead of an attack on the hosts it covers.

--- a/services/azure/Microsoft.Network/applicationSecurityGroups/listIpConfigurations.yml
+++ b/services/azure/Microsoft.Network/applicationSecurityGroups/listIpConfigurations.yml
@@ -1,0 +1,12 @@
+name: Application security group
+description: An Application Security Group (ASG) is a logical grouping of network interfaces (by application role) that can be referenced as the source/destination of NSG rules, instead of explicit IP ranges, to scope firewall rules to a set of VMs.
+scope: HIGH
+notes: An ASG is a perimeter/segmentation control referenced by NSG rules; membership in one determines which firewall rules apply to a given interface, so misuse indirectly controls network access the same way an NSG does. Rated consistent with the other network-segmentation resources documented alongside it.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - discovery:network
+    notes: Lists the IP configurations (interfaces/VMs) that are members of the ASG, revealing which hosts belong to a given application tier and are therefore in scope for any NSG rule that references this group; useful for mapping which hosts to target to inherit or evade that rule's access.


### PR DESCRIPTION
Adds privilege risk classifications for: Microsoft.Network

Part of a larger effort to expand Azure IAM privilege catalog coverage, split into smaller reviewable batches.