### PR TITLE
Azure: add privilege classifications (azure/catalog-classifications-16)

### DIFF
--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationMigrationItems/pauseReplication.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationMigrationItems/pauseReplication.yml
@@ -1,0 +1,12 @@
+name: Pause Site Recovery migration item replication
+description: Pauses ongoing replication for a migration item, halting updates to its replicated copy.
+scope: HIGH
+notes: Pausing replication stops the recovery copy from tracking source changes, so recovery points go stale and the protection silently degrades while the item still appears configured.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - destruction:defense
+    notes: Halts replication so the recovery copy stops updating, quietly eroding recovery readiness without disabling protection outright.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationMigrationItems/testMigrate.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationMigrationItems/testMigrate.yml
@@ -1,0 +1,13 @@
+name: Test migrate Site Recovery migration item
+description: Performs an isolated test migration of a migration item, instantiating a running copy of the workload in a test network without affecting the source.
+scope: HIGH
+notes: A test migration spins up a full running copy of the workload and its data; when directed into an attacker-influenced test network it yields offline access to that data outside production controls.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - exfiltration:data
+      - escalation:lateral
+    notes: Instantiates a live copy of the workload in a chosen test network, letting an attacker access its data and reach it from network positions they control.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems.yml
@@ -1,0 +1,20 @@
+name: Site Recovery replication protected item
+description: A Site Recovery protected item is an individual workload (typically a VM) that is actively replicated to a recovery region, along with its recovery points, target network, and target resource-group configuration.
+scope: CRITICAL
+notes: Protected items are the actual replicated copies of production workloads and their recovery points; removing or reconfiguring them destroys or misdirects the disaster-recovery copy that gates an organization's ability to recover.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - impact:manipulation
+      - destruction:defense
+      - escalation:network
+    notes: Updating a protected item can redirect its recovery target network/resource group or shrink recovery-point retention, redirecting where the DR copy lands and reducing the recoverable history available after an attack.
+  delete:
+    risks:
+      - destruction:defense
+      - destruction:infra
+      - impact:dos
+    notes: Deleting a protected item destroys its replication and recovery points, removing the disaster-recovery copy for that workload; a classic precursor to a destructive/ransomware attack.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/plannedFailover.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/plannedFailover.yml
@@ -1,0 +1,12 @@
+name: Site Recovery protected item planned failover
+description: Triggers a planned failover of a protected item to its recovery region, gracefully moving the running workload to the recovery site.
+scope: CRITICAL
+notes: A planned failover relocates the live workload to the recovery site; though graceful, an unauthorized invocation disrupts production and moves the workload to the configured recovery network.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - impact:dos
+    notes: Moves the running workload to the recovery region, interrupting the production instance.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/remove.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/remove.yml
@@ -1,0 +1,13 @@
+name: Remove Site Recovery protected item
+description: Disables replication for a protected item and removes it from Site Recovery protection.
+scope: CRITICAL
+notes: Removing a protected item stops its replication and discards its recovery points, eliminating the DR copy for that workload.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - destruction:defense
+      - destruction:infra
+    notes: Disables replication and removes the item's recovery points, leaving the workload with no disaster-recovery copy; a ransomware precursor.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/removeDisks.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/removeDisks.yml
@@ -1,0 +1,12 @@
+name: Remove disks from Site Recovery protected item
+description: Removes one or more disks from the set replicated for a protected item, excluding them from ongoing replication and recovery.
+scope: CRITICAL
+notes: Dropping disks from replication silently narrows what is protected, so the excluded data becomes unrecoverable at failover while the item still appears protected.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - destruction:defense
+    notes: Excludes disks from replication, quietly removing their data from the recovery copy without disabling protection on the item as a whole.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/testFailover.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/testFailover.yml
@@ -1,0 +1,13 @@
+name: Site Recovery protected item test failover
+description: Performs an isolated test failover of a protected item, instantiating a running copy of the workload from its recovery point into a test network without affecting the production source.
+scope: CRITICAL
+notes: A test failover spins up a full running copy of the production workload and its data; when directed into an attacker-influenced test network it yields offline access to that data outside production controls.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - exfiltration:data
+      - escalation:lateral
+    notes: Instantiates a live copy of the protected workload in a chosen test network, letting an attacker access the workload's data and reach it from network positions they control.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/unplannedFailover.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectedItems/unplannedFailover.yml
@@ -1,0 +1,13 @@
+name: Site Recovery protected item unplanned failover
+description: Triggers an unplanned failover of a protected item to its recovery region, bringing the workload up from a recovery point without a graceful shutdown of the source.
+scope: CRITICAL
+notes: An unplanned failover forcibly relocates the live workload to the recovery site, which is disruptive to production and can move the workload into an attacker-chosen network or region.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - impact:dos
+      - escalation:network
+    notes: Forces the workload over to the recovery region, disrupting the running service and relocating it into the configured recovery network the attacker may control.


### PR DESCRIPTION
Adds privilege risk classifications for: Microsoft.RecoveryServices

Extends Azure IAM privilege catalog coverage into previously-undocumented resource types (Site Recovery replication / Network governance & perimeter), split into smaller reviewable batches.