### PR TITLE
Azure: add privilege classifications (azure/catalog-classifications-17)

### DIFF
--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionClusters.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionClusters.yml
@@ -1,0 +1,13 @@
+name: Site Recovery replication protection cluster
+description: A Site Recovery protection cluster represents a clustered workload replicated as a unit, coordinating failover of its member protected items together.
+scope: HIGH
+notes: A protection cluster gates coordinated recovery of a clustered workload; deleting it or forcing its failover disrupts or destroys the recovery capability for the whole cluster.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  delete:
+    risks:
+      - destruction:defense
+      - destruction:infra
+    notes: Deleting a protection cluster removes coordinated replication for the clustered workload, destroying its disaster-recovery copy.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionClusters/testFailover.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionClusters/testFailover.yml
@@ -1,0 +1,13 @@
+name: Site Recovery protection cluster test failover
+description: Performs an isolated test failover of a protection cluster, instantiating a running copy of the clustered workload into a test network without affecting production.
+scope: HIGH
+notes: A test failover spins up a full running copy of the clustered workload and its data; when directed into an attacker-influenced test network it yields offline access to that data outside production controls.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - exfiltration:data
+      - escalation:lateral
+    notes: Instantiates a live copy of the clustered workload in a chosen test network, letting an attacker access its data and reach it from network positions they control.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionClusters/unplannedFailover.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationFabrics/replicationProtectionContainers/replicationProtectionClusters/unplannedFailover.yml
@@ -1,0 +1,13 @@
+name: Site Recovery protection cluster unplanned failover
+description: Triggers an unplanned failover of a protection cluster to its recovery region, bringing the clustered workload up from recovery points without a graceful source shutdown.
+scope: HIGH
+notes: An unplanned cluster failover forcibly relocates the clustered workload to the recovery site, disrupting production and moving it into the configured recovery network.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - impact:dos
+      - escalation:network
+    notes: Forces the clustered workload over to the recovery region, disrupting the running service and relocating it into the configured recovery network the attacker may control.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationRecoveryPlans.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationRecoveryPlans.yml
@@ -1,0 +1,18 @@
+name: Site Recovery replication recovery plan
+description: A Site Recovery recovery plan orchestrates failover of a group of protected items in a defined sequence, including pre/post steps such as Azure Automation runbooks and manual actions.
+scope: CRITICAL
+notes: Recovery plans define the org's coordinated failover orchestration and can invoke automation; manipulating one can sabotage recovery or inject attacker-controlled steps, and deleting one removes the ability to recover the grouped workloads in a coordinated way.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - impact:manipulation
+      - destruction:defense
+      - escalation:lateral
+    notes: Editing a recovery plan can reorder or break the failover sequence (defeating orderly recovery) and can add Azure Automation runbook steps that execute in the automation account's context, giving an attacker a code-execution foothold.
+  delete:
+    risks:
+      - destruction:defense
+    notes: Deleting a recovery plan removes the orchestration needed to fail the grouped workloads over in a coordinated way, degrading disaster-recovery capability even though the underlying protected items persist.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationRecoveryPlans/plannedFailover.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationRecoveryPlans/plannedFailover.yml
@@ -1,0 +1,12 @@
+name: Site Recovery recovery plan planned failover
+description: Triggers a planned failover of all protected items in a recovery plan to their recovery region, gracefully moving the grouped workloads to the recovery site.
+scope: CRITICAL
+notes: A planned failover relocates every workload in the plan to the recovery site; though graceful, an unauthorized invocation broadly disrupts production for the whole group.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - impact:dos
+    notes: Moves every workload in the plan to the recovery region, interrupting the production instances across the group.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationRecoveryPlans/testFailover.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationRecoveryPlans/testFailover.yml
@@ -1,0 +1,13 @@
+name: Site Recovery recovery plan test failover
+description: Performs an isolated test failover of a recovery plan, instantiating running copies of all its protected workloads into a test network without affecting production.
+scope: CRITICAL
+notes: A test failover spins up full running copies of every workload in the plan and their data; when directed into an attacker-influenced test network it yields offline access to that data across the group outside production controls.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - exfiltration:data
+      - escalation:lateral
+    notes: Instantiates live copies of every workload in the plan in a chosen test network, letting an attacker access their data and reach them from network positions they control.

--- a/services/azure/Microsoft.RecoveryServices/Vaults/replicationRecoveryPlans/unplannedFailover.yml
+++ b/services/azure/Microsoft.RecoveryServices/Vaults/replicationRecoveryPlans/unplannedFailover.yml
@@ -1,0 +1,13 @@
+name: Site Recovery recovery plan unplanned failover
+description: Triggers an unplanned failover of all protected items in a recovery plan to their recovery region, without a graceful source shutdown.
+scope: CRITICAL
+notes: An unplanned failover of a recovery plan forcibly relocates every workload in the plan to the recovery site at once, a broad disruption that also moves the workloads into their configured recovery networks.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.RecoveryServices
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - impact:dos
+      - escalation:network
+    notes: Forces every workload in the plan over to the recovery region, causing broad service disruption and relocating them into the configured recovery networks the attacker may control.


### PR DESCRIPTION
Adds privilege risk classifications for: Microsoft.RecoveryServices

Extends Azure IAM privilege catalog coverage into previously-undocumented resource types (Site Recovery replication / Network governance & perimeter), split into smaller reviewable batches.