### PR TITLE
Azure: add privilege classifications (azure/catalog-classifications-18)

### DIFF
--- a/services/azure/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies.yml
+++ b/services/azure/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies.yml
@@ -1,0 +1,19 @@
+name: Application Gateway WAF policy
+description: An Application Gateway Web Application Firewall (WAF) policy is the managed rule engine that inspects and filters HTTP/S traffic to internet-facing applications fronted by an Application Gateway, blocking common web attacks.
+scope: HIGH
+notes: A WAF policy is the security control filtering traffic to public applications; weakening or removing it exposes the fronted apps to attack, so mutation of the policy is a defense/policy concern.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - destruction:policy
+      - destruction:defense
+      - impact:manipulation
+    notes: Creating/updating the policy lets an attacker rewrite or disable WAF rules (e.g. flip to detection-only or drop rules), removing the security control filtering traffic to the fronted applications.
+  delete:
+    risks:
+      - destruction:policy
+      - destruction:defense
+    notes: Deleting the policy removes the WAF rule set entirely, tearing down the security control that inspects traffic to the fronted applications.

--- a/services/azure/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/attachWafPolicyToAgc.yml
+++ b/services/azure/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/attachWafPolicyToAgc.yml
@@ -1,0 +1,12 @@
+name: Application Gateway WAF policy
+description: An Application Gateway Web Application Firewall (WAF) policy is the managed rule engine that inspects and filters HTTP/S traffic to internet-facing applications fronted by an Application Gateway, blocking common web attacks.
+scope: HIGH
+notes: A WAF policy is the security control filtering traffic to public applications; weakening or removing it exposes the fronted apps to attack, so mutation of the policy is a defense/policy concern.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - escalation:network
+    notes: Attaches a WAF policy to an Application Gateway for Containers, letting an attacker bind the gateway to an attacker-chosen/weaker policy and bypass the intended filtering posture.

--- a/services/azure/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/detachWafPolicyFromAgc.yml
+++ b/services/azure/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/detachWafPolicyFromAgc.yml
@@ -1,0 +1,13 @@
+name: Application Gateway WAF policy
+description: An Application Gateway Web Application Firewall (WAF) policy is the managed rule engine that inspects and filters HTTP/S traffic to internet-facing applications fronted by an Application Gateway, blocking common web attacks.
+scope: HIGH
+notes: A WAF policy is the security control filtering traffic to public applications; weakening or removing it exposes the fronted apps to attack, so mutation of the policy is a defense/policy concern.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - destruction:defense
+      - destruction:policy
+    notes: Detaches the WAF policy from an Application Gateway for Containers, stripping the traffic-filtering security control off the gateway entirely and leaving the fronted applications unprotected.

--- a/services/azure/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/join.yml
+++ b/services/azure/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/join.yml
@@ -1,0 +1,12 @@
+name: Application Gateway WAF policy
+description: An Application Gateway Web Application Firewall (WAF) policy is the managed rule engine that inspects and filters HTTP/S traffic to internet-facing applications fronted by an Application Gateway, blocking common web attacks.
+scope: HIGH
+notes: A WAF policy is the security control filtering traffic to public applications; weakening or removing it exposes the fronted apps to attack, so mutation of the policy is a defense/policy concern.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - escalation:network
+    notes: Joining a WAF policy binds a gateway/resource to an attacker-chosen (potentially weaker) policy rather than the intended one, bypassing segmentation/policy controls; flagged Not Alertable.

--- a/services/azure/Microsoft.Network/ipGroups.yml
+++ b/services/azure/Microsoft.Network/ipGroups.yml
@@ -1,0 +1,17 @@
+name: IP Group
+description: An IP Group is a reusable named set of IP addresses/ranges referenced by Azure Firewall and NSG rules, letting many rules share a single maintained address list.
+scope: HIGH
+notes: An IP Group is referenced by firewall/NSG rules; changing its ranges silently reshapes every rule that references it, making it a policy-bearing object.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - destruction:policy
+      - impact:manipulation
+    notes: Creating/updating an IP Group rewrites the address ranges that referencing firewall/NSG rules enforce; an attacker can silently widen an allow-list (e.g. add attacker IPs) across every rule that consumes the group, weakening the effective policy.
+  delete:
+    risks:
+      - impact:dos
+    notes: Deleting an IP Group removes the address list that referencing firewall/NSG rules depend on, breaking or degrading those rules and the traffic they govern.

--- a/services/azure/Microsoft.Network/ipGroups/join.yml
+++ b/services/azure/Microsoft.Network/ipGroups/join.yml
@@ -1,0 +1,12 @@
+name: IP Group
+description: An IP Group is a reusable named set of IP addresses/ranges referenced by Azure Firewall and NSG rules, letting many rules share a single maintained address list.
+scope: HIGH
+notes: An IP Group is referenced by firewall/NSG rules; changing its ranges silently reshapes every rule that references it, making it a policy-bearing object.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - escalation:network
+    notes: Joining an IP Group lets a principal reference/attach the group into firewall or NSG rules it does not otherwise control, bypassing the segmentation control that gates which address lists a rule may use; flagged Not Alertable.

--- a/services/azure/Microsoft.Network/loadBalancers/backendAddressPools.yml
+++ b/services/azure/Microsoft.Network/loadBalancers/backendAddressPools.yml
@@ -1,0 +1,18 @@
+name: Load balancer backend address pool
+description: A backend address pool is the set of target addresses (VMs, NICs, or IPs) that an Azure load balancer distributes incoming traffic to.
+scope: HIGH
+notes: The backend pool determines where a load balancer forwards traffic; altering its membership can redirect client traffic to attacker-controlled targets or remove legitimate ones.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - escalation:network
+      - exfiltration:data
+      - impact:manipulation
+    notes: Creating/updating the pool lets an attacker add attacker-controlled backends (receiving client traffic fronted by the load balancer) or remove legitimate backends, enabling traffic redirection/interception and manipulation of which targets serve the service.
+  delete:
+    risks:
+      - impact:dos
+    notes: Deleting the backend pool removes the set of targets the load balancer forwards to, denying service to the fronted application.

--- a/services/azure/Microsoft.Network/loadBalancers/backendAddressPools/join.yml
+++ b/services/azure/Microsoft.Network/loadBalancers/backendAddressPools/join.yml
@@ -1,0 +1,12 @@
+name: Load balancer backend address pool
+description: A backend address pool is the set of target addresses (VMs, NICs, or IPs) that an Azure load balancer distributes incoming traffic to.
+scope: HIGH
+notes: The backend pool determines where a load balancer forwards traffic; altering its membership can redirect client traffic to attacker-controlled targets or remove legitimate ones.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - escalation:network
+    notes: Joining a backend address pool lets a principal attach a resource (e.g. an attacker-controlled NIC/VM) into the pool it does not otherwise control, placing it behind the load balancer to receive fronted traffic; flagged Not Alertable.


### PR DESCRIPTION
Adds privilege risk classifications for: Microsoft.Network

Extends Azure IAM privilege catalog coverage into previously-undocumented resource types (Site Recovery replication / Network governance & perimeter), split into smaller reviewable batches.