### PR TITLE
Azure: add privilege classifications (azure/catalog-classifications-19)

### DIFF
--- a/services/azure/Microsoft.Network/loadBalancers/backendAddressPools/updateAdminState.yml
+++ b/services/azure/Microsoft.Network/loadBalancers/backendAddressPools/updateAdminState.yml
@@ -1,0 +1,12 @@
+name: Load balancer backend address pool
+description: A backend address pool is the set of target addresses (VMs, NICs, or IPs) that an Azure load balancer distributes incoming traffic to.
+scope: HIGH
+notes: The backend pool determines where a load balancer forwards traffic; altering its membership can redirect client traffic to attacker-controlled targets or remove legitimate ones.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - impact:dos
+    notes: Updates the admin state of backend addresses, letting an attacker forcibly mark legitimate backends down so the load balancer stops forwarding to them, denying service.

--- a/services/azure/Microsoft.Network/networkManagers.yml
+++ b/services/azure/Microsoft.Network/networkManagers.yml
@@ -1,0 +1,19 @@
+name: Network Manager
+description: Azure Virtual Network Manager is a centralized governance layer that authors and pushes connectivity configurations and security-admin rules across many VNets at once within a defined network group scope.
+scope: CRITICAL
+notes: A single manager governs connectivity and security-admin rules across many VNets simultaneously; security-admin rules override per-VNet NSGs, so control of the manager is an org-wide policy/segmentation blast-radius multiplier, warranting CRITICAL.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - escalation:network
+      - destruction:policy
+      - impact:manipulation
+    notes: Creating/updating a manager lets an attacker author connectivity and security-admin rule configurations (which override NSGs) across the managed VNet scope; the configuration is staged here and takes effect on commit.
+  delete:
+    risks:
+      - destruction:policy
+      - impact:dos
+    notes: Deleting a manager tears down the centralized connectivity/security-admin governance across all managed VNets, removing org-wide security policy and disrupting the connectivity it maintained.

--- a/services/azure/Microsoft.Network/networkManagers/commit.yml
+++ b/services/azure/Microsoft.Network/networkManagers/commit.yml
@@ -1,0 +1,14 @@
+name: Network Manager
+description: Azure Virtual Network Manager is a centralized governance layer that authors and pushes connectivity configurations and security-admin rules across many VNets at once within a defined network group scope.
+scope: CRITICAL
+notes: A single manager governs connectivity and security-admin rules across many VNets simultaneously; security-admin rules override per-VNet NSGs, so control of the manager is an org-wide policy/segmentation blast-radius multiplier, warranting CRITICAL.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - escalation:network
+      - destruction:policy
+      - impact:manipulation
+    notes: Commit deploys the staged connectivity/security-admin configuration across the managed VNet scope, actually taking effect; an attacker can punch connectivity between many VNets (lateral movement) or override per-VNet NSG rules org-wide in a single operation.

--- a/services/azure/Microsoft.Network/networkManagers/ipamPools.yml
+++ b/services/azure/Microsoft.Network/networkManagers/ipamPools.yml
@@ -1,0 +1,17 @@
+name: Network Manager IPAM pool
+description: An IPAM pool within Azure Virtual Network Manager is a managed reservation of IP address space from which Azure and non-Azure resources draw non-overlapping allocations.
+scope: MEDIUM
+notes: Primarily an address-space inventory/management object; abuse is limited to allocation manipulation that can cause routing/overlap problems rather than direct data or policy compromise.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - impact:manipulation
+      - impact:dos
+    notes: Creating/updating a pool alters the managed address space; overlapping or reshaped ranges can break allocation logic and induce routing/addressing conflicts for resources drawing from the pool.
+  delete:
+    risks:
+      - impact:dos
+    notes: Deleting a pool removes the address-space reservation that dependent resources allocate from, disrupting provisioning and addressing.

--- a/services/azure/Microsoft.Network/networkManagers/listActiveConnectivityConfigurations.yml
+++ b/services/azure/Microsoft.Network/networkManagers/listActiveConnectivityConfigurations.yml
@@ -1,0 +1,13 @@
+name: Network Manager
+description: Azure Virtual Network Manager is a centralized governance layer that authors and pushes connectivity configurations and security-admin rules across many VNets at once within a defined network group scope.
+scope: CRITICAL
+notes: A single manager governs connectivity and security-admin rules across many VNets simultaneously; security-admin rules override per-VNet NSGs, so control of the manager is an org-wide policy/segmentation blast-radius multiplier, warranting CRITICAL.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - discovery:network
+    notes: Lists the connectivity configurations currently in effect across the managed VNet scope, revealing which VNets are meshed/hub-connected and thus the reachable network topology for lateral movement.
+    scope: MEDIUM

--- a/services/azure/Microsoft.Network/networkManagers/listActiveSecurityAdminRules.yml
+++ b/services/azure/Microsoft.Network/networkManagers/listActiveSecurityAdminRules.yml
@@ -1,0 +1,13 @@
+name: Network Manager
+description: Azure Virtual Network Manager is a centralized governance layer that authors and pushes connectivity configurations and security-admin rules across many VNets at once within a defined network group scope.
+scope: CRITICAL
+notes: A single manager governs connectivity and security-admin rules across many VNets simultaneously; security-admin rules override per-VNet NSGs, so control of the manager is an org-wide policy/segmentation blast-radius multiplier, warranting CRITICAL.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - discovery:network
+    notes: Lists the security-admin rules currently in effect across the managed VNet scope, disclosing the org-wide enforced firewall posture an attacker can use to find gaps.
+    scope: MEDIUM

--- a/services/azure/Microsoft.Network/networkManagers/listActiveSecurityUserRules.yml
+++ b/services/azure/Microsoft.Network/networkManagers/listActiveSecurityUserRules.yml
@@ -1,0 +1,13 @@
+name: Network Manager
+description: Azure Virtual Network Manager is a centralized governance layer that authors and pushes connectivity configurations and security-admin rules across many VNets at once within a defined network group scope.
+scope: CRITICAL
+notes: A single manager governs connectivity and security-admin rules across many VNets simultaneously; security-admin rules override per-VNet NSGs, so control of the manager is an org-wide policy/segmentation blast-radius multiplier, warranting CRITICAL.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - discovery:network
+    notes: Lists the security-user rules currently in effect across the managed VNet scope, disclosing the enforced network filtering posture an attacker can use to find gaps.
+    scope: MEDIUM

--- a/services/azure/Microsoft.Network/networkProfiles.yml
+++ b/services/azure/Microsoft.Network/networkProfiles.yml
@@ -1,0 +1,17 @@
+name: Network Profile
+description: A Network Profile defines container networking configuration (container network interfaces and their subnet/IP settings) used to attach container workloads to a VNet.
+scope: HIGH
+notes: Controls how container workloads are wired into the VNet; manipulation can place attacker workloads on the network or reattach existing ones into different segments.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - escalation:network
+      - impact:manipulation
+    notes: Creating/updating a profile defines the container NIC/subnet wiring; an attacker can attach container workloads into a chosen VNet segment, gaining network reach and altering the intended networking configuration.
+  delete:
+    risks:
+      - impact:dos
+    notes: Deleting a profile removes the container networking configuration that dependent container workloads rely on, disrupting their connectivity.


### PR DESCRIPTION
Adds privilege risk classifications for: Microsoft.Network

Extends Azure IAM privilege catalog coverage into previously-undocumented resource types (Site Recovery replication / Network governance & perimeter), split into smaller reviewable batches.