### PR TITLE
Azure: add privilege classifications (azure/catalog-classifications-21)

### DIFF
--- a/services/azure/Microsoft.Network/securityPartnerProviders/join.yml
+++ b/services/azure/Microsoft.Network/securityPartnerProviders/join.yml
@@ -1,0 +1,12 @@
+name: Security Partner Provider
+description: A Security Partner Provider routes traffic through a third-party security service (e.g. a cloud-delivered firewall) for inspection before it reaches its destination.
+scope: HIGH
+notes: Sits in the traffic path as a security-inspection hop; removing or rerouting it disables inspection or diverts traffic away from the intended security service.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - escalation:network
+    notes: Joining a Security Partner Provider lets a principal bind a resource to an attacker-chosen inspection path it does not otherwise control, bypassing the intended segmentation/inspection control; flagged Not Alertable.

--- a/services/azure/Microsoft.Network/virtualHubs.yml
+++ b/services/azure/Microsoft.Network/virtualHubs.yml
@@ -1,0 +1,19 @@
+name: Virtual Hub
+description: A Virtual Hub is the routing core of an Azure Virtual WAN, terminating branch/VNet connections and holding the route tables that steer traffic across the WAN.
+scope: HIGH
+notes: The hub is the central routing point of a Virtual WAN; controlling its routing redirects or intercepts traffic across every connected VNet and branch.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - escalation:network
+      - exfiltration:data
+      - impact:manipulation
+    notes: Creating/updating a hub lets an attacker rewrite the WAN routing that steers traffic between connected VNets and branches, redirecting or intercepting flows across the WAN and tampering with routing configuration.
+  delete:
+    risks:
+      - destruction:network
+      - impact:dos
+    notes: Deleting the hub removes the routing core of the Virtual WAN, tearing down a network component and cutting connectivity for every VNet and branch attached to it.

--- a/services/azure/Microsoft.Network/virtualHubs/effectiveRoutes.yml
+++ b/services/azure/Microsoft.Network/virtualHubs/effectiveRoutes.yml
@@ -1,0 +1,13 @@
+name: Virtual Hub
+description: A Virtual Hub is the routing core of an Azure Virtual WAN, terminating branch/VNet connections and holding the route tables that steer traffic across the WAN.
+scope: HIGH
+notes: The hub is the central routing point of a Virtual WAN; controlling its routing redirects or intercepts traffic across every connected VNet and branch.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - discovery:network
+    notes: Returns the effective routes on the hub, disclosing the WAN's reachable topology and next-hops; inboundRoutes and outboundRoutes are equivalent route-disclosure actions carrying the same discovery risk.
+    scope: MEDIUM

--- a/services/azure/Microsoft.Network/virtualHubs/inboundRoutes.yml
+++ b/services/azure/Microsoft.Network/virtualHubs/inboundRoutes.yml
@@ -1,0 +1,13 @@
+name: Virtual Hub
+description: A Virtual Hub is the routing core of an Azure Virtual WAN, terminating branch/VNet connections and holding the route tables that steer traffic across the WAN.
+scope: HIGH
+notes: The hub is the central routing point of a Virtual WAN; controlling its routing redirects or intercepts traffic across every connected VNet and branch.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - discovery:network
+    notes: Returns the routes learnt from a Virtual WAN connection, disclosing WAN topology and advertised prefixes usable to plan lateral movement.
+    scope: MEDIUM

--- a/services/azure/Microsoft.Network/virtualHubs/outboundRoutes.yml
+++ b/services/azure/Microsoft.Network/virtualHubs/outboundRoutes.yml
@@ -1,0 +1,13 @@
+name: Virtual Hub
+description: A Virtual Hub is the routing core of an Azure Virtual WAN, terminating branch/VNet connections and holding the route tables that steer traffic across the WAN.
+scope: HIGH
+notes: The hub is the central routing point of a Virtual WAN; controlling its routing redirects or intercepts traffic across every connected VNet and branch.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.Network
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - discovery:network
+    notes: Returns the routes advertised by a Virtual WAN connection, disclosing WAN topology and reachable prefixes usable to plan lateral movement.
+    scope: MEDIUM


### PR DESCRIPTION
Adds privilege risk classifications for: Microsoft.Network

Extends Azure IAM privilege catalog coverage into previously-undocumented resource types (Site Recovery replication / Network governance & perimeter), split into smaller reviewable batches.