### PR TITLE
Azure: add privilege classifications (azure/catalog-classifications-28)

### DIFF
--- a/services/azure/Microsoft.OperationalInsights/workspaces/purge.yml
+++ b/services/azure/Microsoft.OperationalInsights/workspaces/purge.yml
@@ -1,0 +1,13 @@
+name: Log Analytics workspace data purge
+description: Deletes specified data records by query from a Log Analytics workspace.
+scope: HIGH
+notes: Query-targeted deletion of individual log records is the classic anti-forensics primitive; it removes evidence at row granularity, so the operation is HIGH.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.OperationalInsights
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - destruction:logs
+      - destruction:defense
+    notes: Deletes matching log records by query, letting an attacker surgically erase the traces of their own activity and defeat the audit trail.

--- a/services/azure/Microsoft.OperationalInsights/workspaces/savedSearches.yml
+++ b/services/azure/Microsoft.OperationalInsights/workspaces/savedSearches.yml
@@ -1,0 +1,17 @@
+name: Log Analytics saved search
+description: A saved search query in a workspace; when paired with a schedule it forms a Log Analytics alert rule that drives detections.
+scope: HIGH
+notes: Saved searches back scheduled alert rules, so tampering with or removing them degrades detection logic; HIGH.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.OperationalInsights
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - impact:manipulation
+      - destruction:defense
+    notes: Rewriting a saved search can neuter the detection query behind an alert rule so malicious activity no longer matches.
+  delete:
+    risks:
+      - destruction:defense
+    notes: Deleting a saved search removes the query behind a detection, disabling the alert built on it.

--- a/services/azure/Microsoft.OperationalInsights/workspaces/savedSearches/schedules.yml
+++ b/services/azure/Microsoft.OperationalInsights/workspaces/savedSearches/schedules.yml
@@ -1,0 +1,17 @@
+name: Log Analytics saved search schedule
+description: A schedule attached to a saved search that runs the query on an interval, turning it into a recurring Log Analytics alert rule.
+scope: HIGH
+notes: The schedule is what makes a saved search fire as a detection; disabling or removing it stops the alert from ever running; HIGH.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.OperationalInsights
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - impact:manipulation
+      - destruction:defense
+    notes: Altering a schedule (e.g. disabling it or widening its interval) suppresses how often the detection runs, blinding it.
+  delete:
+    risks:
+      - destruction:defense
+    notes: Deleting a schedule stops the saved search from running, removing the detection entirely.

--- a/services/azure/Microsoft.OperationalInsights/workspaces/savedSearches/schedules/actions.yml
+++ b/services/azure/Microsoft.OperationalInsights/workspaces/savedSearches/schedules/actions.yml
@@ -1,0 +1,17 @@
+name: Log Analytics scheduled search action
+description: An action attached to a scheduled saved search that fires when the alert triggers, such as sending a notification or invoking a webhook.
+scope: HIGH
+notes: Actions are how a triggered alert reaches responders; removing or altering them silences the response even when the detection fires; HIGH.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.OperationalInsights
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - impact:manipulation
+      - destruction:defense
+    notes: Rewriting an alert action can redirect or disable the notification/webhook, so a triggered detection never reaches responders.
+  delete:
+    risks:
+      - destruction:defense
+    notes: Deleting an alert action leaves the detection firing silently with no notification or response.

--- a/services/azure/Microsoft.OperationalInsights/workspaces/search.yml
+++ b/services/azure/Microsoft.OperationalInsights/workspaces/search.yml
@@ -1,0 +1,13 @@
+name: Log Analytics search
+description: Executes a search query against the log data stored in a workspace.
+scope: HIGH
+notes: Query access reads back stored log data, which can include sensitive records; it is closer to bulk read than to targeted export, so it is HIGH.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.OperationalInsights
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - exfiltration:logs
+      - discovery:data
+    notes: Runs arbitrary queries over stored logs, allowing bulk read-out of telemetry and inventory of what data the workspace holds.

--- a/services/azure/Microsoft.OperationalInsights/workspaces/storageinsightconfigs.yml
+++ b/services/azure/Microsoft.OperationalInsights/workspaces/storageinsightconfigs.yml
@@ -1,0 +1,18 @@
+name: Log Analytics storage insight configuration
+description: A storage insight configuration that pulls log data from a linked storage account (e.g. diagnostic logs, WAD/LAD tables) into the workspace.
+scope: HIGH
+notes: These configs are an ingestion path from storage into the workspace; removing them stops that telemetry from being read in; HIGH.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.OperationalInsights
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - destruction:logs
+      - destruction:defense
+    notes: Altering a storage insight config can stop or narrow the log data pulled from storage, suppressing future telemetry.
+  delete:
+    risks:
+      - destruction:logs
+      - destruction:defense
+    notes: Deleting a storage insight config stops the workspace reading logs from the storage account, cutting that ingestion source.

--- a/services/azure/Microsoft.OperationalInsights/workspaces/tables.yml
+++ b/services/azure/Microsoft.OperationalInsights/workspaces/tables.yml
@@ -1,0 +1,18 @@
+name: Log Analytics table
+description: A table within a Log Analytics workspace that stores a specific stream of log records; tables define schema, retention, and ingestion for their data.
+scope: HIGH
+notes: A table holds a distinct class of security log evidence and controls its retention, so tampering with or dropping it removes specific detection data; HIGH.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.OperationalInsights
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  write:
+    risks:
+      - impact:manipulation
+      - destruction:logs
+    notes: Updating a table can cut its retention or alter its schema, silently dropping or truncating the log evidence it stores.
+  delete:
+    risks:
+      - destruction:logs
+      - destruction:data
+    notes: Dropping a table destroys all log records it holds, erasing a whole category of evidence.

--- a/services/azure/Microsoft.OperationalInsights/workspaces/tables/deleteData.yml
+++ b/services/azure/Microsoft.OperationalInsights/workspaces/tables/deleteData.yml
@@ -1,0 +1,13 @@
+name: Log Analytics table data deletion
+description: Deletes data from a table in a Log Analytics workspace.
+scope: HIGH
+notes: Table-granular deletion of log records is the same anti-forensics class as workspace purge, applied to a single evidence stream; HIGH.
+links:
+  - https://azure.permissions.cloud/iam/Microsoft.OperationalInsights
+  - https://learn.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+privileges:
+  action:
+    risks:
+      - destruction:logs
+      - destruction:defense
+    notes: Deletes log records from a table, erasing specific evidence and defeating the detections that read from it.


### PR DESCRIPTION
Adds privilege risk classifications for: Microsoft.OperationalInsights

Detection & response evasion themed batch (Microsoft Sentinel / Defender for Cloud / Log Analytics), extending coverage of previously-undocumented security-monitoring operations. Split into smaller reviewable batches.